### PR TITLE
Translate skill descriptions to English

### DIFF
--- a/skills/2agent/SKILL.md
+++ b/skills/2agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 2agent
-description: "Configures 2-Agent workflow between PM and implementation roles. Use when user mentions 2-Agent, 2エージェント, PM連携設定, Cursor設定, Cursor連携, 2-agent運用. Do NOT load for: 単独運用, ワークフロー実行, ハンドオフ処理."
+description: "Configures 2-Agent workflow between PM and implementation roles. Use when user mentions 2-Agent setup, PM coordination, Cursor setup, or 2-agent operations. Do NOT load for: solo operation, workflow execution, or handoff processing."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/auth/SKILL.md
+++ b/skills/auth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: auth
-description: "Implements authentication and payment features using Clerk, Supabase Auth, or Stripe. Use when user mentions ログイン, 認証, auth, authentication, Clerk, Supabase, 決済, payment, Stripe, 課金, サブスクリプション. Do NOT load for: 一般的なUI作成, データベース設計, 非認証機能."
+description: "Implements authentication and payment features using Clerk, Supabase Auth, or Stripe. Use when user mentions login, authentication, payments, subscriptions, or Stripe. Do NOT load for: general UI work, database design, or non-auth features."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/ci/SKILL.md
+++ b/skills/ci/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ci
-description: "Diagnoses and fixes CI/CD pipeline failures. Use when user mentions 'CI', 'GitHub Actions', 'GitLab CI', 'ビルドエラー', 'テスト失敗', 'パイプライン', 'CIが落ちた', or asks to analyze build/test failures. Do NOT load for: ローカルビルド, 通常の実装作業, レビュー, セットアップ."
+description: "Diagnoses and fixes CI/CD pipeline failures. Use when user mentions CI failures, build errors, test failures, or pipeline issues. Do NOT load for: local builds, standard implementation work, reviews, or setup."
 allowed-tools: ["Read", "Grep", "Bash", "Task"]
 context: fork
 ---

--- a/skills/codex-review/SKILL.md
+++ b/skills/codex-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codex-review
-description: "OpenAI Codex CLI を MCP サーバーとして統合し、セカンドオピニオンレビューを提供。トリガー: 'Codex でレビュー', 'セカンドオピニオン', 'Codex 設定', '別の AI にも見てもらって', 'Codex review'. Do NOT load for: 通常のレビュー（Codex 不要時）、実装作業、セットアップ以外。"
+description: "Integrates OpenAI Codex CLI as an MCP server to provide second-opinion reviews. Triggered by requests for Codex review, second opinion, or Codex setup. Do NOT load for: standard reviews without Codex, implementation work, or non-setup tasks."
 allowed-tools: ["Bash", "Read", "Write", "Edit"]
 ---
 

--- a/skills/cursor-mem/SKILL.md
+++ b/skills/cursor-mem/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cursor-mem
-description: "Cursorでclaude-memのMCPサーバーにアクセスし、過去のセッション記録を検索・新しい観測を記録。トリガー: 'メモリ検索', 'claude-mem', '過去の判断', '記録して', 'memory search', 'past decisions'. Do NOT load for: 通常のコーディング、一時的なメモ、実装作業。"
+description: "Accesses the claude-mem MCP server from Cursor to search session history and record observations. Triggers: memory search, claude-mem, past decisions, record this. Do NOT load for: normal coding, temporary notes, or implementation work."
 allowed-tools: ["Bash", "Read", "mcp__claude-mem__*"]
 ---
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy
-description: "Sets up deployment, analytics, and health monitoring for projects. Use when user mentions デプロイ, deploy, Vercel, Netlify, 公開, アナリティクス, analytics, GA, Google Analytics, 環境診断, health check. Do NOT load for: 実装作業, ローカル開発, レビュー, セットアップ."
+description: "Sets up deployment, analytics, and health monitoring for projects. Use when user mentions deployment, Vercel, Netlify, analytics, or health checks. Do NOT load for: implementation work, local development, reviews, or setup."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/dev-browser/SKILL.md
+++ b/skills/dev-browser/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dev-browser
-description: "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include \"go to [url]\", \"click on\", \"fill out the form\", \"take a screenshot\", \"scrape\", \"automate\", \"test the website\", \"log into\", or any browser interaction request."
+description: "Browser automation with persistent page state. Use when users ask to navigate websites, fill forms, take screenshots, extract web data, test web apps, or automate browser workflows. Trigger phrases include 'go to [url]', 'click on', 'fill out the form', 'take a screenshot', 'scrape', 'automate', 'test the website', 'log into', or any browser interaction request."
 allowed-tools: ["Bash", "Read"]
 context: fork
 ---

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: "Generates documentation files including NotebookLM YAML and slide content. Use when user mentions ドキュメント, document, YAML, NotebookLM, スライド, slide, プレゼン. Do NOT load for: 実装作業, コード修正, レビュー, デプロイ."
+description: "Generates documentation files including NotebookLM YAML and slide content. Use when user mentions documentation, YAML, NotebookLM, slides, or presentations. Do NOT load for: implementation work, code fixes, reviews, or deployments."
 allowed-tools: ["Read", "Write", "Edit"]
 ---
 

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl
-description: "Implements features and writes code based on Plans.md tasks. Use when user mentions 実装, implement, 機能追加, コードを書いて, 機能を作って, feature, coding, 新機能, implementing functions, classes, or features, 新しい関数. Do not use for review or build verification."
+description: "Implements features and writes code based on Plans.md tasks. Use when user mentions implementation, adding features, writing code, or creating new functions. Do not use for review or build verification."
 allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash"]
 ---
 

--- a/skills/maintenance/SKILL.md
+++ b/skills/maintenance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maintenance
-description: "Cleans up and organizes project files. Use when user mentions '整理', 'cleanup', 'アーカイブ', 'archive', '肥大化', 'Plans.md', 'session-log', or asks to clean up old tasks, archive completed items, or organize files. Do NOT load for: 実装作業, レビュー, 新機能開発, デプロイ."
+description: "Cleans up and organizes project files. Use when user mentions cleanup, archive, file bloat, or organizing Plans.md/session logs. Do NOT load for: implementation work, reviews, new feature development, or deployment."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/memory/SKILL.md
+++ b/skills/memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory
-description: "Manages memory, SSOT files, and Plans.md operations. Use when user mentions メモリ, memory, SSOT, decisions.md, patterns.md, マージ, merge, Plans.md, 移行, migrate. Do NOT load for: 実装作業, レビュー, 一時的なメモ, セッション中の作業記録."
+description: "Manages memory, SSOT files, and Plans.md operations. Use when user mentions memory, SSOT, decisions.md, patterns.md, merging, or migration. Do NOT load for: implementation work, reviews, ad-hoc notes, or in-session logging."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/parallel-workflows/SKILL.md
+++ b/skills/parallel-workflows/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-workflows
-description: "Optimizes parallel execution of multiple tasks. Use when user mentions 並列で実行, 同時にやって, まとめてやって, run in parallel, do these together. Do NOT load for: 単一タスク, 順次実行が必要な作業, 依存関係のあるタスク."
+description: "Optimizes parallel execution of multiple tasks. Use when user mentions running tasks in parallel or together. Do NOT load for: single tasks, sequential-only work, or tasks with dependencies."
 allowed-tools: ["Read", "Task"]
 user-invocable: false
 ---

--- a/skills/plans-management/SKILL.md
+++ b/skills/plans-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plans-management
-description: "Manages Plans.md tasks and marker operations. Use when user mentions タスクを追加, Plans.md更新, 完了マーク, タスク状態変更, add task, update plans, mark complete. Do NOT load for: 実装作業, レビュー, Plans.md以外のファイル操作."
+description: "Manages Plans.md tasks and marker operations. Use when user mentions adding tasks, updating Plans.md, marking complete, or changing task status. Do NOT load for: implementation work, reviews, or non-Plans file operations."
 allowed-tools: ["Read", "Write", "Edit"]
 ---
 

--- a/skills/principles/SKILL.md
+++ b/skills/principles/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: principles
-description: "Provides development principles, guidelines, and VibeCoder guidance. Use when user mentions 原則, principles, ガイドライン, guidelines, VibeCoder, 安全性, safety, 差分編集, diff-aware. Triggers: 原則, principles, ガイドライン, VibeCoder, 安全性, 差分編集. Do not use for actual implementation - use impl skill instead."
+description: "Provides development principles, guidelines, and VibeCoder guidance. Use when user mentions principles, guidelines, safety, or diff-aware editing. Do not use for actual implementation—use the impl skill instead."
 allowed-tools: ["Read"]
 user-invocable: false
 ---

--- a/skills/review/SKILL.md
+++ b/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: "Reviews code for quality, security, performance, and accessibility issues. Use when user mentions レビュー, review, コードレビュー, セキュリティ, パフォーマンス, 品質チェック, セルフレビュー, PR, diff, 変更確認. Do NOT load for: 実装作業, 新機能開発, バグ修正, セットアップ."
+description: "Reviews code for quality, security, performance, and accessibility issues. Use when user mentions reviews, code review, security, performance, quality checks, PRs, diffs, or change review. Do NOT load for: implementation work, new feature development, bug fixes, or setup."
 allowed-tools: ["Read", "Grep", "Glob", "Bash", "Task"]
 context: fork
 ---

--- a/skills/session-init/SKILL.md
+++ b/skills/session-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-init
-description: "Initializes session with environment check and task status overview. Use when user mentions セッション開始, 作業開始, 状況確認, what should I work on, start session. Do NOT load for: 実装作業, レビュー, セッション途中の作業."
+description: "Initializes session with environment checks and task status overview. Use when user mentions starting a session, beginning work, or status checks. Do NOT load for: implementation work, reviews, or mid-session tasks."
 allowed-tools: ["Read", "Write", "Bash"]
 user-invocable: false
 ---

--- a/skills/session-memory/SKILL.md
+++ b/skills/session-memory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-memory
-description: "Manages cross-session learning and memory persistence. Use when user mentions 前回何をした, 履歴, 過去の作業, セッション記録, continue from before, session history. Do NOT load for: 実装作業, レビュー, 一時的な情報."
+description: "Manages cross-session learning and memory persistence. Use when user asks about previous sessions, history, or to continue from before. Do NOT load for: implementation work, reviews, or ad-hoc information."
 allowed-tools: ["Read", "Write", "Append"]
 user-invocable: false
 ---

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup
-description: "Sets up new projects and generates workflow files like CLAUDE.md, AGENTS.md, Plans.md. Use when user mentions セットアップ, setup, 初期化, initialize, 新規プロジェクト, ワークフローファイル生成. Do NOT load for: 実装作業, レビュー, ビルド検証, デプロイ."
+description: "Sets up new projects and generates workflow files like CLAUDE.md, AGENTS.md, Plans.md. Use when user mentions setup, initialization, new projects, or workflow file generation. Do NOT load for: implementation work, reviews, build verification, or deployments."
 allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash"]
 user-invocable: false
 ---

--- a/skills/troubleshoot/SKILL.md
+++ b/skills/troubleshoot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: troubleshoot
-description: "Guides diagnosis and resolution when problems occur. Use when user mentions 動かない, エラーが出た, 壊れた, うまくいかない, broken, doesn't work, error. Do NOT load for: 正常なビルド, 新機能実装, レビュー."
+description: "Guides diagnosis and resolution when problems occur. Use when user mentions something broken, errors, or that it doesn't work. Do NOT load for: successful builds, new feature implementation, or reviews."
 allowed-tools: ["Read", "Grep", "Bash"]
 context: fork
 ---

--- a/skills/ui/SKILL.md
+++ b/skills/ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ui
-description: "Generates UI components and feedback forms. Use when user mentions コンポーネント, component, UI, ヒーロー, hero, フォーム, form, フィードバック, feedback, 問い合わせ. Do NOT load for: 認証機能, バックエンド実装, データベース操作, ビジネスロジック."
+description: "Generates UI components and feedback forms. Use when user mentions components, UI, hero sections, forms, feedback, or contact requests. Do NOT load for: authentication features, backend implementation, database operations, or business logic."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 

--- a/skills/verify/SKILL.md
+++ b/skills/verify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: verify
-description: "Verifies builds, recovers from errors, and applies review fixes. Use when user mentions ビルド, build, 検証, verify, エラー復旧, error recovery, 指摘を適用, apply fixes, テスト実行, tests fail, lint errors occur, CI breaks, テスト失敗, lintエラー, 型エラー, ビルドエラー, CIが落ちた. Do NOT load for: 実装作業, レビュー, セットアップ, 新機能開発."
+description: "Verifies builds, recovers from errors, and applies review fixes. Use when user mentions build verification, error recovery, applying review fixes, test failures, lint errors, or CI breaks. Do NOT load for: implementation work, reviews, setup, or new feature development."
 allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash"]
 ---
 

--- a/skills/vibecoder-guide/SKILL.md
+++ b/skills/vibecoder-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vibecoder-guide
-description: "Guides VibeCoder (non-technical users) through natural language development. Use when user mentions どうすればいい, 次は何, 使い方, 困った, help, what should I do. Do NOT load for: 技術者向け作業, 直接的な実装指示, レビュー."
+description: "Guides VibeCoder (non-technical users) through natural language development. Use when user asks what to do next, how to use the system, needs help, or is stuck. Do NOT load for: technical-user work, direct implementation requests, or reviews."
 allowed-tools: ["Read"]
 user-invocable: false
 ---

--- a/skills/workflow-guide/SKILL.md
+++ b/skills/workflow-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-guide
-description: "Provides guidance on Cursor ↔ Claude Code 2-agent workflow. Use when user mentions ワークフローについて, Cursorとの連携, 作業の流れ, 2-agent workflow, collaboration. Do NOT load for: 実装作業, ワークフロー設定, ハンドオフ実行."
+description: "Provides guidance on Cursor ↔ Claude Code 2-agent workflow. Use when user asks about workflow, collaboration, or process. Do NOT load for: implementation work, workflow setup, or executing handoffs."
 allowed-tools: ["Read"]
 user-invocable: false
 ---

--- a/skills/workflow/SKILL.md
+++ b/skills/workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workflow
-description: "Manages workflow transitions including handoffs between PM and implementation roles, and auto-fixes review comments. Use when user mentions ハンドオフ, handoff, PMに報告, 実装役に渡して, レビュー指摘を自動修正, auto-fix. Triggers: ハンドオフ, handoff, PMに報告, 実装役に渡して, 完了報告, 自動修正, auto-fix. Do not use for 2-Agent setup - use 2agent skill instead."
+description: "Manages workflow transitions including handoffs between PM and implementation roles, and auto-fixes review comments. Use when user mentions handoffs, reporting to PM, handing off to implementation, completion reports, or auto-fix. Do not use for 2-Agent setup—use 2agent skill instead."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
 ---
 


### PR DESCRIPTION
### Motivation
- Normalize and English-localize skill front-matter `description` fields so triggers and exclusion notes are consistently phrased in English for better context compression and clearer intent detection.
- Fix a YAML quoting issue in the dev-browser skill description to avoid nested double-quotes that can break YAML parsing in some tools.

### Description
- Updated the `description` front-matter for 24 skill metadata files under `skills/*/SKILL.md` to English-only phrasing and clearer trigger/exclusion language.
- Normalized wording (e.g. Japanese phrases and mixed-language fragments replaced with concise English tokens like `implementation`, `test failures`, `deployment`, etc.).
- Adjusted `skills/dev-browser/SKILL.md` to use single quotes around trigger phrases inside the double-quoted `description` to avoid nested-quote issues.
- Only metadata `description` lines were changed; the body content of skills remains intact.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696cc5c7b3508320986c3982261207f7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * 複数のスキルファイルの説明文をを日本語/バイリンガル形式から英語のみに統一更新しました
  * スキル使用時のトリガー条件と除外条件の説明をより簡潔で明確な英語表現に改善しました

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->