### PR TITLE
feat: add disable-model-invocation to Task content skills

### DIFF
--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -2,6 +2,7 @@
 name: deploy
 description: "Sets up deployment, analytics, and health monitoring for projects. Use when user mentions deployment, Vercel, Netlify, analytics, or health checks. Do NOT load for: implementation work, local development, reviews, or setup."
 allowed-tools: ["Read", "Write", "Edit", "Bash"]
+disable-model-invocation: true
 ---
 
 # Deploy Skills

--- a/skills/video/SKILL.md
+++ b/skills/video/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: video
-description: "Generates product demo videos, architecture explanations, and release note videos. Use when user mentions video generation, product demos, or visual documentation. Requires Remotion setup."
+description: "Generates product demo videos, architecture explanations, and release note videos. Use when user mentions '/video', video generation, product demos, or visual documentation. Do NOT load for: embedding video players, live demos, video playback features. Requires Remotion setup."
 allowed-tools: ["Read", "Write", "Edit", "Grep", "Glob", "Bash", "Task", "AskUserQuestion", "WebFetch"]
+disable-model-invocation: true
 ---
 
 # Video Generation Skills


### PR DESCRIPTION
Per official Claude Code Skills documentation, Task content skills (deployments, commits, code generation) should have disable-model-invocation: true to prevent Claude from triggering them automatically.

- deploy: deployment setup (side effects)
- video: video generation (heavy side effects)

Also improved video description with "Do NOT load for" pattern.

https://claude.ai/code/session_01BRUvdz9BZmbRBeXierHWRR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **機能更新**
  * デプロイスキルにモデル呼び出しを無効化する設定を追加
  * ビデオスキルの説明を更新し、トリガーハンドリングを改善、モデル呼び出しを無効化する設定を追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->