### PR TITLE
chore(ci): v4.0.3 regression の再発防止 2 点

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Added
+
+#### validate-plugin.sh に plugin.json の skills パス検証を追加
+
+**今まで**: `.claude-plugin/plugin.json` の `skills` フィールドに誤ったパス（例: `["./"]`）を書いても、
+CI の `validate-plugin.sh` はそれを検出できませんでした。実際 v4.0.2 以前ではこのミスが混入しており、
+配布経路で skill が 0 件ロードされる事故をサイレントに許していました。
+
+**今後**: `validate-plugin.sh` のセクション 3 が `plugin.json` の `skills` フィールドを解析し、
+各パスの配下に `SKILL.md` が実在するかを走査します。パスが存在しない、あるいは SKILL.md が 1 件も
+見つからない場合は `fail_test` で CI を落とします。今回のような「書いただけで動かない設定」を
+PR 段階でブロックできるようになりました。
+
+#### sync-version.sh bump に CHANGELOG compare link 自動挿入を追加
+
+**今まで**: `./scripts/sync-version.sh bump` で patch バージョンを上げた後、CHANGELOG.md の
+compare link セクション（末尾の `[Unreleased]: ...` と `[x.y.z]: ...` 行）を手動で更新する必要がありました。
+更新を忘れると `scripts/ci/check-version-bump.sh` が落ちます（実際 v4.0.3 のリリース時に踏みました）。
+
+**今後**: `bump` サブコマンドが自動で `[Unreleased]` 行の比較元を新バージョンに書き換え、
+`[新バージョン]: .../compare/v<旧>...v<新>` 行を直後に挿入します。CI の release metadata check に
+一発で通るリリース手順になります。
+
 ## [4.0.3] - 2026-04-13
 
 ### テーマ: プラグイン配布時の skill ロード失敗を修正

--- a/scripts/sync-version.sh
+++ b/scripts/sync-version.sh
@@ -85,6 +85,54 @@ sync_version() {
     echo "✅ 同期完了: $version"
 }
 
+# CHANGELOG.md の compare link を更新 (Unreleased のバージョン差し替え + 新バージョン行を挿入)
+update_changelog_compare_links() {
+    local current="$1"
+    local new="$2"
+    local changelog="CHANGELOG.md"
+
+    if [ ! -f "$changelog" ]; then
+        return 0
+    fi
+
+    python3 - "$changelog" "$current" "$new" <<'PY'
+import re
+import sys
+
+changelog, current, new = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(changelog, "r", encoding="utf-8") as fh:
+    lines = fh.readlines()
+
+pattern = re.compile(
+    rf"^\[Unreleased\]: (https://github\.com/[^/]+/[^/]+)/compare/v{re.escape(current)}\.\.\.HEAD\s*$"
+)
+
+new_lines = []
+inserted = False
+for line in lines:
+    match = pattern.match(line)
+    if match and not inserted:
+        repo = match.group(1)
+        new_lines.append(f"[Unreleased]: {repo}/compare/v{new}...HEAD\n")
+        new_lines.append(f"[{new}]: {repo}/compare/v{current}...v{new}\n")
+        inserted = True
+        continue
+    new_lines.append(line)
+
+if not inserted:
+    print(
+        f"⚠️  CHANGELOG.md に [Unreleased] compare link (v{current}...HEAD) が見つかりません。手動で追加してください。",
+        file=sys.stderr,
+    )
+    sys.exit(0)
+
+with open(changelog, "w", encoding="utf-8") as fh:
+    fh.writelines(new_lines)
+
+print(f"✅ CHANGELOG.md に compare link を追加: [{new}]")
+PY
+}
+
 # パッチバージョンを上げる
 bump_version() {
     local current=$(get_version)
@@ -99,6 +147,7 @@ bump_version() {
     echo "✅ VERSION を更新: $current → $new_version"
 
     sync_version
+    update_changelog_compare_links "$current" "$new_version"
 }
 
 # メイン

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -144,6 +144,59 @@ echo ""
 echo "3. スキルの検証"
 echo "----------------------------------------"
 
+# plugin.json の skills パス先に SKILL.md が実在するかチェック（v4.0.3 regression guard）
+# skills: ["./"] のような誤設定で配布時に 0 件ロードされる事故を再発させないため、
+# plugin.json の skills フィールドが指すディレクトリを実際に走査し、SKILL.md の存在を検証する。
+skills_path_check_output=$(python3 - "$PLUGIN_ROOT/.claude-plugin/plugin.json" "$PLUGIN_ROOT" <<'PY' 2>&1
+import json
+import os
+import sys
+
+manifest_path, plugin_root = sys.argv[1], sys.argv[2]
+with open(manifest_path, "r", encoding="utf-8") as fh:
+    manifest = json.load(fh)
+
+skills_field = manifest.get("skills", "./skills/")
+if isinstance(skills_field, str):
+    paths = [skills_field]
+elif isinstance(skills_field, list):
+    paths = skills_field
+else:
+    print("skills field must be string or array of strings", file=sys.stderr)
+    sys.exit(2)
+
+errors = []
+details = []
+for entry in paths:
+    resolved = os.path.normpath(os.path.join(plugin_root, entry))
+    if not os.path.isdir(resolved):
+        errors.append(f"path does not exist: {entry}")
+        continue
+    count = 0
+    for dirpath, _dirnames, filenames in os.walk(resolved):
+        if "SKILL.md" in filenames:
+            count += 1
+    if count == 0:
+        errors.append(f"no SKILL.md found under: {entry}")
+    else:
+        details.append(f"{entry} -> {count} skills")
+
+if errors:
+    for err in errors:
+        print(err, file=sys.stderr)
+    sys.exit(1)
+
+print(", ".join(details))
+PY
+)
+skills_path_check_status=$?
+
+if [ $skills_path_check_status -eq 0 ]; then
+    pass_test "plugin.json の skills パス先に SKILL.md が実在します ($skills_path_check_output)"
+else
+    fail_test "plugin.json の skills パス先に SKILL.md が見つかりません: $skills_path_check_output"
+fi
+
 # スキルディレクトリの存在
 if [ -d "$PLUGIN_ROOT/skills" ]; then
     SKILL_COUNT=$(find "$PLUGIN_ROOT/skills" -name "SKILL.md" | wc -l)


### PR DESCRIPTION
## Summary

v4.0.3 でサイレントに混入していた 2 つの落とし穴を CI/ツール側で塞ぐ。

- **validate-plugin.sh**: `.claude-plugin/plugin.json` の `skills` フィールドが指すパス配下に `SKILL.md` が実在するかを走査し、0 件なら `fail_test` で落とす。`skills: ["./"]` のような「書いただけで動かない設定」を PR 段階で検出可能に。
- **sync-version.sh bump**: CHANGELOG の compare link 行（`[Unreleased]: .../compare/v<x>...HEAD` と `[<new>]: .../compare/v<x>...v<new>`）を自動更新。リリース時に手動編集を忘れて `check-version-bump.sh` で落ちるパターン（v4.0.3 で実際に踏んだ）を予防。

## Why

PR #73 (v4.0.3) で以下 2 つの問題が顕在化した:

1. `plugin.json` の skills パス誤設定 (`["./"]`) が CI で検出されず、配布時に skill 0 件ロードという致命的バグが本番リリースまで到達した
2. `sync-version.sh bump` 実行後に CHANGELOG compare link を手動追記する必要があり、CI で落ちてリリースが 1 サイクル止まった

両方とも「機械的にチェック可能なもの」で、本 PR で自動化する。

## Test Plan

- [x] `bash tests/validate-plugin.sh` が現状の `skills: "./skills/"` で PASS することを確認
- [x] 仮想 plugin.json (`skills: ["./"]`) で Python helper を単独実行し `no SKILL.md found under: ./` の検出と exit 1 を確認
- [x] 仮想 CHANGELOG.md で compare link insertion を単独実行し、`[Unreleased]` が新バージョンに書き換わり新エントリが挿入されることを確認
- [ ] CI の `validate` / `test-go` ジョブが pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プラグインの検証時にスキルパスの存在確認を自動化
  * バージョン更新時にCHANGELOGの比較リンクを自動で生成・更新

* **Chores**
  * ドキュメント更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->