### PR TITLE
fix(sync): harness sync が plugin.json の skills パスを書き戻す回帰を修正

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -16,6 +16,8 @@
     "workflow",
     "plan-work-review"
   ],
-  "skills": "./skills/",
+  "skills": [
+    "./skills/"
+  ],
   "outputStyles": "./output-styles/"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Fixed
+
+#### harness sync が plugin.json の skills パスを ["./"] に書き戻す回帰バグを修正
+
+**今まで**: Go 製の `harness sync` コマンド（`go/cmd/harness/sync.go`）の `pluginJSON` 構造体 Skills フィールドに
+`[]string{"./"}` がハードコードされており、`sync` を実行するたびに
+`.claude-plugin/plugin.json` の `skills` フィールドを `["./"]` に書き戻していました。
+これは v4.0.3 で修正した「配布時 skill 0 件ロード問題」の修正値（`"./skills/"`）を
+静かに破壊する動作で、`sync-skill-mirrors.sh` や `harness-release` の Phase 4 が走るたびに
+v4.0.3 の fix が undo されてしまう回帰の温床でした。
+
+**今後**: ハードコード値を `[]string{"./skills/"}` に修正し、`sync_test.go` の expectation も同期。
+`harness sync` 実行後も plugin.json の skills パスが `"./skills/"` 相当を保持します。
+合わせて、plugin.json の skills フィールドは `harness sync` の出力に合わせて
+配列形式 `["./skills/"]` に正規化しました（CC 2.1.94+ は string / array 両方を受理するため動作は等価）。
+
 ### Added
 
 #### validate-plugin.sh に plugin.json の skills パス検証を追加

--- a/go/cmd/harness/sync.go
+++ b/go/cmd/harness/sync.go
@@ -100,8 +100,13 @@ type pluginJSON struct {
 	License      string      `json:"license,omitempty"`
 	Keywords     []string    `json:"keywords,omitempty"`
 	// Skills declares the skill discovery roots per CC 2.1.94+.
-	// With ["./"], CC uses each SKILL.md frontmatter `name` field as the
-	// invocation name, allowing directory name and invocation name to differ.
+	// Points to the directory containing skill subdirectories (each with SKILL.md).
+	// Previously hardcoded to ["./"] per 009faf74, which assumed SKILL.md lived at
+	// the plugin root. That assumption did not match this repo's layout (SKILL.md
+	// files are under `skills/`), so `claude plugin install` / `--plugin-dir`
+	// discovered zero skills. v4.0.3 (25bd633d) fixed plugin.json to "./skills/"
+	// but the sync regenerator still wrote back "./"; this field now emits
+	// "./skills/" so subsequent syncs preserve the fix.
 	Skills       []string    `json:"skills,omitempty"`
 	OutputStyles string      `json:"outputStyles,omitempty"`
 }
@@ -128,10 +133,11 @@ func generatePluginJSON(projectRoot string, cfg *config.Config) error {
 		Repository:   cfg.Project.Repository,
 		License:      cfg.Project.License,
 		Keywords:     cfg.Project.Keywords,
-		// Always emit ["./"] so CC 2.1.94+ uses frontmatter `name` fields
-		// for skill invocation. This enables short-name aliases like
-		// HAR:plan while keeping directory names unchanged.
-		Skills:       []string{"./"},
+		// Emit ["./skills/"] so CC 2.1.94+ can discover SKILL.md files under the
+		// actual skills directory. The earlier ["./"] value (009faf74) pointed to
+		// the plugin root where no SKILL.md exists, causing distributed installs
+		// (`claude plugin install`, `--plugin-dir`) to load zero skills.
+		Skills:       []string{"./skills/"},
 		OutputStyles: cfg.Project.OutputStyles,
 	}
 

--- a/go/cmd/harness/sync_test.go
+++ b/go/cmd/harness/sync_test.go
@@ -117,8 +117,11 @@ func TestSync_GeneratesPluginJSON(t *testing.T) {
 	if v["homepage"] != "https://github.com/Chachamaru127/claude-code-harness" {
 		t.Errorf("plugin.json homepage = %v", v["homepage"])
 	}
-	// CC 2.1.94+: skills field must be ["./"] so frontmatter `name` drives
-	// invocation. Prevents auto-revert regression when harness sync runs.
+	// CC 2.1.94+: skills field must be ["./skills/"] so CC discovers SKILL.md
+	// files under the actual skills directory. The earlier ["./"] value caused
+	// distributed installs (`claude plugin install`, `--plugin-dir`) to load
+	// zero skills because no SKILL.md exists at the plugin root (v4.0.3 fix).
+	// Prevents auto-revert regression when harness sync runs.
 	skillsRaw, ok := v["skills"]
 	if !ok {
 		t.Fatalf("plugin.json missing skills field")
@@ -127,8 +130,8 @@ func TestSync_GeneratesPluginJSON(t *testing.T) {
 	if !ok {
 		t.Fatalf("plugin.json skills = %v (type %T), want []interface{}", skillsRaw, skillsRaw)
 	}
-	if len(skills) != 1 || skills[0] != "./" {
-		t.Errorf("plugin.json skills = %v, want [./]", skills)
+	if len(skills) != 1 || skills[0] != "./skills/" {
+		t.Errorf("plugin.json skills = %v, want [./skills/]", skills)
 	}
 }
 


### PR DESCRIPTION
## Summary

v4.0.3 で修正した「配布時 skill 0 件ロード問題」の fix 値 (`"./skills/"`) を、Go 製 `harness sync` コマンドが毎回 `["./"]` に書き戻していた**サイレント回帰バグ**を修正。

## Root Cause

- コミット **009faf74** が `go/cmd/harness/sync.go:134` に `Skills: []string{"./"}` をハードコード
- 意図は「CC 2.1.94+ で frontmatter `name` を invocation name として使う」こと
- しかしプラグインルートに `SKILL.md` は存在せず（実体は `skills/` 配下）、`["./"]` では skill が発見できない
- v4.0.3 (25bd633d) が plugin.json を `"./skills/"` に修正したが、Go コードはそのままだった
- 以降、`sync-skill-mirrors.sh` / `harness-release` の Phase 4 などで間接的に `harness sync` が走るたび plugin.json が `["./"]` に戻されていた（本セッション中に 3 回観測）

詳細調査結果（サブエージェント）:
- A: `["./"]` は物理的に skill を見つけられない → 実証済み
- B: 009faf74 の「HAR:* alias」仕様解釈は正しいが、実装前提（root に SKILL.md）が欠けている → 構造と不整合

## Changes

| ファイル | 変更 |
|---------|------|
| `go/cmd/harness/sync.go:134` | `[]string{"./"}` → `[]string{"./skills/"}` |
| `go/cmd/harness/sync.go:102-104, 131-133` | コメント更新（背景と修正経緯を記録） |
| `go/cmd/harness/sync_test.go:120-131` | expectation を `"./skills/"` に同期、コメント更新 |
| `.claude-plugin/plugin.json` | `harness sync` 出力に合わせて配列形式 `["./skills/"]` に正規化 |
| `CHANGELOG.md` | [Unreleased] に記録 |

## Test Plan

- [x] `cd go && go test ./cmd/harness/` が全 PASS（101s、37テスト）
- [x] `bash tests/validate-plugin.sh` が PASS（skills パス検証: 33 skills detected）
- [x] `./bin/harness sync` 実行後、plugin.json の skills が `["./skills/"]` のまま維持されることを確認
- [ ] CI validate / test-go pass

## Related

- PR #73 (v4.0.3 fix): plugin.json の skills パスを修正
- PR #74: validate-plugin.sh に skills パス検証追加（今回の再発を事前検出する仕組み）
- PR #77 (open): release skill 分割（本 PR と独立、別件マージ可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プラグイン設定ファイルの同期処理において、スキルパスが不正な値で上書きされるバグを修正しました。スキル検出パスが正しい位置に保持されるようになります。

* **ドキュメント**
  * プラグイン設定ファイルのスキルフィールド形式を統一し、設定方法を明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->