### PR TITLE
fix: protect codex setup from skill symlink hazards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Change history for claude-code-harness.
 
 ### Fixed
 
+- `codex-setup-local.sh` now treats existing skill symlinks as links instead of recursing into their targets. User-level Codex setup can safely preserve a symlink that already points at the current Harness source, or replace a stale symlink without moving files out of the source tree. Backup names also get a collision-safe suffix so repeated basenames such as `SKILL.md` are not overwritten within one run.
 - Claude Code hook command resolution now falls back safely when `CLAUDE_PLUGIN_ROOT` is missing or invalid. Hook commands validate the resolved `claude-code-harness` plugin root before executing `bin/harness`, preventing empty plugin roots from becoming `/bin/harness` and producing `hook exited with code 127`.
 - `sync-plugin-cache.sh` now validates the plugin root and updates an installed local marketplace copy when present, so stale marketplace hook definitions do not keep using raw `${CLAUDE_PLUGIN_ROOT}` commands after the versioned cache is fixed.
 - Sprint-contract generation now omits inactive pointer fields such as `review.rubric_target`, preventing release preflight from rejecting non-UI contracts that previously serialized those fields as `null`.

--- a/scripts/codex-setup-local.sh
+++ b/scripts/codex-setup-local.sh
@@ -82,7 +82,7 @@ resolve_plugin_dir() {
 backup_path() {
   local target="$1"
   local backup_root="$2"
-  if [ -e "$target" ]; then
+  if [ -e "$target" ] || [ -L "$target" ]; then
     local ts
     local base
     local dst
@@ -90,9 +90,81 @@ backup_path() {
     base="$(basename "$target")"
     mkdir -p "$backup_root"
     dst="$backup_root/${base}.${ts}.$$"
+    local suffix=1
+    while [ -e "$dst" ] || [ -L "$dst" ]; do
+      dst="$backup_root/${base}.${ts}.$$.$suffix"
+      suffix=$((suffix + 1))
+    done
     mv "$target" "$dst"
     echo "Backed up $target to $dst"
   fi
+}
+
+same_physical_path() {
+  local left="$1"
+  local right="$2"
+
+  [ -e "$left" ] || return 1
+  [ -e "$right" ] || return 1
+
+  local left_real
+  local right_real
+  left_real="$(physical_path "$left")"
+  right_real="$(physical_path "$right")"
+
+  [ "$left_real" = "$right_real" ]
+}
+
+physical_path() {
+  local path="$1"
+
+  if [ -d "$path" ]; then
+    (cd "$path" && pwd -P)
+    return 0
+  fi
+
+  if [ -L "$path" ]; then
+    local link_target
+    link_target="$(readlink "$path")" || return 1
+    case "$link_target" in
+      /*)
+        physical_path "$link_target"
+        ;;
+      *)
+        physical_path "$(dirname "$path")/$link_target"
+        ;;
+    esac
+    return $?
+  fi
+
+  (cd "$(dirname "$path")" && printf '%s/%s\n' "$(pwd -P)" "$(basename "$path")")
+}
+
+copy_sync_entry() {
+  local src="$1"
+  local dst_dir="$2"
+
+  cp -R -L "$src" "$dst_dir/"
+}
+
+sync_entry_to_path() {
+  local src="$1"
+  local dst_path="$2"
+  local dst_dir="$3"
+  local backup_root="$4"
+
+  if [ -L "$dst_path" ]; then
+    if same_physical_path "$src" "$dst_path"; then
+      return 1
+    fi
+    backup_path "$dst_path" "$backup_root"
+    copy_sync_entry "$src" "$dst_dir"
+    return 0
+  fi
+
+  backup_path "$dst_path" "$backup_root"
+  copy_sync_entry "$src" "$dst_dir"
+  return 0
 }
 
 should_skip_sync_entry() {
@@ -258,20 +330,24 @@ merge_dir_recursive() {
 
   local entry
   for entry in "$src_dir"/*; do
-    [ -e "$entry" ] || continue
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
     local name
     name="$(basename "$entry")"
     local dst_path="$dst_dir/$name"
 
-    if [ ! -e "$dst_path" ]; then
-      cp -R -L "$entry" "$dst_dir/"
+    if [ ! -e "$dst_path" ] && [ ! -L "$dst_path" ]; then
+      copy_sync_entry "$entry" "$dst_dir"
       eval "$_copied_ref=\$((\$$_copied_ref + 1))"
+    elif [ -L "$dst_path" ]; then
+      if sync_entry_to_path "$entry" "$dst_path" "$dst_dir" "$backup_root"; then
+        eval "$_updated_ref=\$((\$$_updated_ref + 1))"
+      fi
     elif [ -d "$entry" ] && [ -d "$dst_path" ]; then
       merge_dir_recursive "$entry" "$dst_path" "$backup_root" "$_copied_ref" "$_updated_ref"
     else
-      backup_path "$dst_path" "$backup_root"
-      cp -R -L "$entry" "$dst_dir/"
-      eval "$_updated_ref=\$((\$$_updated_ref + 1))"
+      if sync_entry_to_path "$entry" "$dst_path" "$dst_dir" "$backup_root"; then
+        eval "$_updated_ref=\$((\$$_updated_ref + 1))"
+      fi
     fi
   done
 }
@@ -291,7 +367,7 @@ sync_named_children() {
   local preserved=0
   local entry
   for entry in "$src_dir"/*; do
-    [ -e "$entry" ] || continue
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
     local name
     name="$(basename "$entry")"
     if should_skip_sync_entry "$name"; then
@@ -300,20 +376,26 @@ sync_named_children() {
     fi
     local dst_path="$dst_dir/$name"
 
-    if [ ! -e "$dst_path" ]; then
-      cp -R -L "$entry" "$dst_dir/"
+    if [ ! -e "$dst_path" ] && [ ! -L "$dst_path" ]; then
+      copy_sync_entry "$entry" "$dst_dir"
       copied=$((copied + 1))
+    elif [ -L "$dst_path" ]; then
+      if sync_entry_to_path "$entry" "$dst_path" "$dst_dir" "$backup_root"; then
+        updated=$((updated + 1))
+      else
+        preserved=$((preserved + 1))
+      fi
     elif [ -d "$entry" ] && [ -d "$dst_path" ]; then
       merge_dir_recursive "$entry" "$dst_path" "$backup_root" "copied" "updated"
     else
-      backup_path "$dst_path" "$backup_root"
-      cp -R -L "$entry" "$dst_dir/"
-      updated=$((updated + 1))
+      if sync_entry_to_path "$entry" "$dst_path" "$dst_dir" "$backup_root"; then
+        updated=$((updated + 1))
+      fi
     fi
   done
 
   for entry in "$dst_dir"/*; do
-    [ -e "$entry" ] || continue
+    [ -e "$entry" ] || [ -L "$entry" ] || continue
     local name
     name="$(basename "$entry")"
     if should_skip_sync_entry "$name"; then

--- a/tests/test-codex-package.sh
+++ b/tests/test-codex-package.sh
@@ -381,6 +381,15 @@ else
   log_fail "Setup script duplicate-skill guards are missing"
 fi
 
+log_test "codex-setup-local handles symlinked skill installs safely"
+if bash tests/test-codex-setup-local.sh >/tmp/codex-setup-symlink.$$ 2>&1; then
+  log_pass "Symlinked skill installs are safe"
+else
+  cat /tmp/codex-setup-symlink.$$ | sed 's/^/  /'
+  log_fail "Symlinked skill install safety check failed"
+fi
+rm -f /tmp/codex-setup-symlink.$$ || true
+
 # Test 1.7b: setup-codex should not inject stale notify config
 log_test "setup-codex.sh avoids stale notify config"
 if rg -q '^\[notify\]' "scripts/setup-codex.sh"; then

--- a/tests/test-codex-setup-local.sh
+++ b/tests/test-codex-setup-local.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# test-codex-setup-local.sh
+# Regression tests for Codex local setup safety.
+#
+# The setup script must never follow a user-level skill symlink and move files
+# out of the Harness source tree while trying to back up an existing install.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "${TMP_ROOT}"' EXIT
+
+run_setup() {
+  local home_dir="$1"
+  local codex_home="$home_dir/.codex"
+
+  HOME="$home_dir" \
+    CODEX_HOME="$codex_home" \
+    CLAUDE_PLUGIN_ROOT="$ROOT_DIR" \
+    bash "$ROOT_DIR/scripts/codex-setup-local.sh" --user >/tmp/codex-setup-local.$$ 2>&1
+}
+
+assert_file() {
+  local file="$1"
+  if [ ! -f "$file" ]; then
+    echo "expected file to exist: $file" >&2
+    exit 1
+  fi
+}
+
+assert_symlink() {
+  local path="$1"
+  if [ ! -L "$path" ]; then
+    echo "expected symlink: $path" >&2
+    exit 1
+  fi
+}
+
+assert_not_symlink() {
+  local path="$1"
+  if [ -L "$path" ]; then
+    echo "expected non-symlink path: $path" >&2
+    exit 1
+  fi
+}
+
+SOURCE_SKILL="$ROOT_DIR/codex/.codex/skills/breezing"
+SOURCE_SKILL_FILE="$SOURCE_SKILL/SKILL.md"
+
+assert_file "$SOURCE_SKILL_FILE"
+
+# Case 1: the user skill is a symlink to the current source skill.
+# This is already up to date, so setup should preserve the symlink and must not
+# recurse into it as if it were a normal directory.
+HOME_ONE="$TMP_ROOT/home-source-link"
+CODEX_ONE="$HOME_ONE/.codex"
+mkdir -p "$CODEX_ONE/skills"
+ln -s "$SOURCE_SKILL" "$CODEX_ONE/skills/breezing"
+
+run_setup "$HOME_ONE"
+
+assert_symlink "$CODEX_ONE/skills/breezing"
+assert_file "$SOURCE_SKILL_FILE"
+
+# Case 2: the user skill is a symlink to some other local directory.
+# Setup should back up the symlink itself, replace it with a real copied skill
+# directory, and leave the external symlink target untouched.
+HOME_TWO="$TMP_ROOT/home-stale-link"
+CODEX_TWO="$HOME_TWO/.codex"
+STALE_TARGET="$TMP_ROOT/stale-breezing"
+mkdir -p "$CODEX_TWO/skills" "$STALE_TARGET"
+printf 'stale skill target\n' > "$STALE_TARGET/SKILL.md"
+ln -s "$STALE_TARGET" "$CODEX_TWO/skills/breezing"
+
+run_setup "$HOME_TWO"
+
+assert_not_symlink "$CODEX_TWO/skills/breezing"
+assert_file "$CODEX_TWO/skills/breezing/SKILL.md"
+assert_file "$STALE_TARGET/SKILL.md"
+if ! grep -Fq 'stale skill target' "$STALE_TARGET/SKILL.md"; then
+  echo "stale symlink target was modified" >&2
+  exit 1
+fi
+
+# Case 3: multiple files with the same basename can be backed up in one run.
+# Backups are stored in one flat directory, so the script must add a suffix
+# instead of overwriting an earlier backup from the same second/process.
+HOME_THREE="$TMP_ROOT/home-backup-collision"
+CODEX_THREE="$HOME_THREE/.codex"
+mkdir -p "$CODEX_THREE/skills/harness-loop" "$CODEX_THREE/skills/harness-plan"
+printf 'old harness-loop\n' > "$CODEX_THREE/skills/harness-loop/SKILL.md"
+printf 'old harness-plan\n' > "$CODEX_THREE/skills/harness-plan/SKILL.md"
+
+run_setup "$HOME_THREE"
+
+backup_count="$(
+  find "$CODEX_THREE/backups/codex-setup-local" -type f -name 'SKILL.md.*' | wc -l | tr -d ' '
+)"
+if [ "$backup_count" -lt 2 ]; then
+  echo "expected at least 2 SKILL.md backups, found $backup_count" >&2
+  exit 1
+fi
+
+echo "OK"


### PR DESCRIPTION
## Summary
- keep existing skill symlinks from being traversed during codex local setup
- replace stale symlinks by backing up the link itself, leaving the target untouched
- add collision-safe backup names and a regression test for symlink installs

## Tests
- bash tests/test-codex-setup-local.sh
- bash tests/test-codex-package.sh
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * シンボリックリンク処理が改善されました。既存のシンボリックリンクが現在のハーネスソースを参照している場合、それらを安全に保持できるようになりました
  * バックアップファイル名の衝突を防ぐため、命名規則を改善しました。同じベース名を持つ複数のファイルが同一実行内で上書きされることがなくなりました

* **テスト**
  * シンボリックリンク処理の安全性と正確性を検証する新しいテストが追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->