### PR TITLE
fix(ci): gate Japanese UX regression in clean checkouts

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -44,7 +44,6 @@ jobs:
           bash ./tests/test-i18n-skill-frontmatter.sh
           bash ./tests/test-i18n-locale-roundtrip.sh
           bash ./tests/test-setup-language-rendering.sh
-          bash ./tests/test-i18n-japanese-ux-regression.sh
 
       - name: Validate plugin structure
         run: |

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -44,6 +44,7 @@ jobs:
           bash ./tests/test-i18n-skill-frontmatter.sh
           bash ./tests/test-i18n-locale-roundtrip.sh
           bash ./tests/test-setup-language-rendering.sh
+          bash ./tests/test-i18n-japanese-ux-regression.sh
 
       - name: Validate plugin structure
         run: |

--- a/scripts/ci/check-consistency.sh
+++ b/scripts/ci/check-consistency.sh
@@ -702,6 +702,8 @@ run_i18n_gate "locale roundtrip idempotency" \
   bash "$PLUGIN_ROOT/tests/test-i18n-locale-roundtrip.sh"
 run_i18n_gate "setup language rendering" \
   bash "$PLUGIN_ROOT/tests/test-setup-language-rendering.sh"
+run_i18n_gate "Japanese UX opt-in surfaces" \
+  bash "$PLUGIN_ROOT/tests/test-i18n-japanese-ux-regression.sh"
 
 if [ $I18N_ISSUES -eq 0 ]; then
   echo "  ✅ i18n 回帰ゲートOK"

--- a/tests/test-i18n-japanese-ux-regression.sh
+++ b/tests/test-i18n-japanese-ux-regression.sh
@@ -160,8 +160,21 @@ assert_contains docs/i18n-language-contract.md "## Japanese UX Regression Bounda
 assert_contains docs/i18n-language-contract.md 'Creative skills such as `x-announce` and `x-article`'
 assert_contains docs/i18n-language-contract.md "Japanese article / post structure"
 assert_contains docs/i18n-language-contract.md "Do not remove Japanese defaults"
-assert_contains skills/x-article/SKILL.md "画像内テキストは日本語を基本にする"
-assert_contains skills/x-announce/SKILL.md "投稿テキスト5本"
+assert_contains codex/.codex/skills/x-article/SKILL.md "画像内テキストは日本語を基本にする"
+assert_contains codex/.codex/skills/x-announce/SKILL.md "投稿テキスト5本"
+
+for optional_source in \
+  skills/x-article/SKILL.md \
+  skills/x-announce/SKILL.md \
+  .agents/skills/x-article/SKILL.md \
+  .agents/skills/x-announce/SKILL.md; do
+  if [ -f "$optional_source" ]; then
+    case "$optional_source" in
+      *x-article*) assert_contains "$optional_source" "画像内テキストは日本語を基本にする" ;;
+      *x-announce*) assert_contains "$optional_source" "投稿テキスト5本" ;;
+    esac
+  fi
+done
 
 python3 - <<'PY'
 from pathlib import Path
@@ -180,7 +193,10 @@ def frontmatter(path: Path) -> dict[str, str]:
     raise AssertionError(f"{path}: unterminated frontmatter")
 
 
-for path in (Path("skills/x-article/SKILL.md"), Path("skills/x-announce/SKILL.md")):
+for path in (
+    Path("codex/.codex/skills/x-article/SKILL.md"),
+    Path("codex/.codex/skills/x-announce/SKILL.md"),
+):
     meta = frontmatter(path)
     assert meta["description"] == meta["description-en"], f"{path}: English discovery default drifted"
     assert meta["description-ja"], f"{path}: Japanese creative metadata disappeared"

--- a/tests/test-i18n-japanese-ux-regression.sh
+++ b/tests/test-i18n-japanese-ux-regression.sh
@@ -41,11 +41,15 @@ copy_dir codex/.codex/skills
 copy_dir opencode/skills
 copy_dir .agents/skills
 
-(
+locale_log="$tmpdir/i18n-japanese-ux-locale.log"
+if ! (
   cd "$tmpdir/repo"
-  bash scripts/i18n/set-locale.sh ja >/tmp/i18n-japanese-ux-locale.$$ 2>&1
-)
-rm -f /tmp/i18n-japanese-ux-locale.$$
+  bash scripts/i18n/set-locale.sh ja
+) >"$locale_log" 2>&1; then
+  echo "set-locale.sh ja failed:" >&2
+  cat "$locale_log" >&2
+  exit 1
+fi
 
 python3 - "$tmpdir/repo" <<'PY'
 import sys


### PR DESCRIPTION
## Summary
- Follow-up from the post-merge harness-review of #112 / #105.
- Makes the Japanese UX regression test assert tracked packaged creative skill surfaces instead of ignored local-only `skills/x-*` directories.
- Adds the Japanese UX regression test to both the GitHub i18n suite and the local consistency i18n gate.

## Why
A clean detached checkout of the #112 merge commit failed `tests/test-i18n-japanese-ux-regression.sh` because the test asserted ignored source-local creative skills. The actual tracked packaged surfaces live under `codex/.codex/skills/x-*`.

## Verification
- `bash tests/test-i18n-japanese-ux-regression.sh`
- `bash scripts/ci/check-consistency.sh`
- `bash ./tests/validate-plugin.sh --quick`
- `git diff --check`
- clean detached worktree at this commit:
  - `bash tests/test-i18n-japanese-ux-regression.sh`
  - `bash scripts/i18n/check-translations.sh`
  - `bash tests/test-i18n-default-language.sh`
  - `bash tests/test-i18n-skill-frontmatter.sh`
  - `bash tests/test-i18n-locale-roundtrip.sh`
  - `bash tests/test-setup-language-rendering.sh`
  - `bash scripts/ci/check-consistency.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * 日本語UXのリグレッションテスト検証を強化しました。

* **Chores**
  * CI処理の日本語UXテスト実行を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->