### PR TITLE
test: guard CCH review gate branch policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Fixed
+
+- Added a CCH branch-protection release preflight guard so GitHub human-review
+  enforcement cannot silently replace the intended `harness-review` / Codex
+  companion approval gate.
+
 ## [4.12.6] - 2026-05-27
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@ Change history for claude-code-harness.
 
 ### Fixed
 
-- Added a CCH branch-protection release preflight guard so GitHub human-review
-  enforcement cannot silently replace the intended `harness-review` / Codex
-  companion approval gate.
+- Added a CCH branch-protection release preflight guard so repository review
+  settings cannot silently drift from the intended CCH review gate.
 
 ## [4.12.6] - 2026-05-27
 

--- a/scripts/check-cch-branch-protection-policy.sh
+++ b/scripts/check-cch-branch-protection-policy.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Verify this repository keeps CCH's review gate policy:
+# harness-review/Codex companion approval + required CI checks, not GitHub human-review enforcement.
+
+set -euo pipefail
+
+JSON_FILE=""
+REPO_SLUG="${HARNESS_BRANCH_PROTECTION_REPO:-}"
+BRANCH="${HARNESS_BRANCH_PROTECTION_BRANCH:-main}"
+REQUIRED_CONTEXTS=(actionlint validate test-go)
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/check-cch-branch-protection-policy.sh [--json PATH] [--repo OWNER/REPO] [--branch NAME]
+
+Checks:
+  - required_pull_request_reviews is null
+  - required status checks are strict and include actionlint, validate, test-go
+  - force pushes and branch deletion are disabled
+
+Without --json, the script reads live GitHub branch protection via gh api.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --json)
+      JSON_FILE="${2:-}"
+      [ -n "$JSON_FILE" ] || { echo "error: --json requires a path" >&2; exit 2; }
+      shift 2
+      ;;
+    --repo)
+      REPO_SLUG="${2:-}"
+      [ -n "$REPO_SLUG" ] || { echo "error: --repo requires OWNER/REPO" >&2; exit 2; }
+      shift 2
+      ;;
+    --branch)
+      BRANCH="${2:-}"
+      [ -n "$BRANCH" ] || { echo "error: --branch requires a branch name" >&2; exit 2; }
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+require_jq() {
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "FAIL: jq is required for branch protection policy validation" >&2
+    exit 1
+  fi
+}
+
+derive_repo_slug() {
+  local remote
+  remote="$(git config --get remote.origin.url 2>/dev/null || true)"
+  case "$remote" in
+    git@github.com:*.git)
+      printf '%s\n' "${remote#git@github.com:}" | sed 's/\.git$//'
+      ;;
+    git@github.com:*)
+      printf '%s\n' "${remote#git@github.com:}"
+      ;;
+    https://github.com/*.git)
+      printf '%s\n' "${remote#https://github.com/}" | sed 's/\.git$//'
+      ;;
+    https://github.com/*)
+      printf '%s\n' "${remote#https://github.com/}"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+load_json() {
+  if [ -n "$JSON_FILE" ]; then
+    cat "$JSON_FILE"
+    return
+  fi
+
+  if [ -z "$REPO_SLUG" ]; then
+    REPO_SLUG="$(derive_repo_slug || true)"
+  fi
+  if [ -z "$REPO_SLUG" ]; then
+    echo "FAIL: could not derive GitHub owner/repo from origin remote" >&2
+    exit 1
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "FAIL: gh CLI is required for live branch protection validation" >&2
+    exit 1
+  fi
+
+  gh api "repos/${REPO_SLUG}/branches/${BRANCH}/protection"
+}
+
+json="$(load_json)"
+require_jq
+
+failures=0
+
+fail_check() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+pass_check() {
+  echo "PASS: $1"
+}
+
+if jq -e '.required_pull_request_reviews == null' >/dev/null <<<"$json"; then
+  pass_check "required_pull_request_reviews is null"
+else
+  fail_check "required_pull_request_reviews must stay null; CCH review gate is harness-review/Codex companion approval"
+fi
+
+if jq -e '.required_status_checks.strict == true' >/dev/null <<<"$json"; then
+  pass_check "required status checks are strict"
+else
+  fail_check "required_status_checks.strict must be true"
+fi
+
+for context in "${REQUIRED_CONTEXTS[@]}"; do
+  if jq -e --arg context "$context" '(.required_status_checks.contexts // []) | index($context) != null' >/dev/null <<<"$json"; then
+    pass_check "required status check includes ${context}"
+  else
+    fail_check "required status checks must include ${context}"
+  fi
+done
+
+if jq -e 'def enabled: if type == "object" then (.enabled // false) else (. // false) end; (.allow_force_pushes | enabled) == false' >/dev/null <<<"$json"; then
+  pass_check "force pushes are disabled"
+else
+  fail_check "allow_force_pushes must be disabled"
+fi
+
+if jq -e 'def enabled: if type == "object" then (.enabled // false) else (. // false) end; (.allow_deletions | enabled) == false' >/dev/null <<<"$json"; then
+  pass_check "branch deletion is disabled"
+else
+  fail_check "allow_deletions must be disabled"
+fi
+
+if [ "$failures" -gt 0 ]; then
+  exit 1
+fi
+
+echo "CCH branch protection policy: ok"

--- a/scripts/check-cch-branch-protection-policy.sh
+++ b/scripts/check-cch-branch-protection-policy.sh
@@ -127,7 +127,12 @@ else
 fi
 
 for context in "${REQUIRED_CONTEXTS[@]}"; do
-  if jq -e --arg context "$context" '(.required_status_checks.contexts // []) | index($context) != null' >/dev/null <<<"$json"; then
+  if jq -e --arg context "$context" '
+    [
+      (.required_status_checks.contexts // [])[],
+      (.required_status_checks.checks // [])[].context
+    ] | index($context) != null
+  ' >/dev/null <<<"$json"; then
     pass_check "required status check includes ${context}"
   else
     fail_check "required status checks must include ${context}"

--- a/scripts/check-cch-branch-protection-policy.sh
+++ b/scripts/check-cch-branch-protection-policy.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# Verify this repository keeps CCH's review gate policy:
-# harness-review/Codex companion approval + required CI checks, not GitHub human-review enforcement.
+# Verify this repository keeps branch settings aligned with CCH's review gate policy.
 
 set -euo pipefail
 
@@ -14,7 +13,7 @@ usage() {
 Usage: scripts/check-cch-branch-protection-policy.sh [--json PATH] [--repo OWNER/REPO] [--branch NAME]
 
 Checks:
-  - required_pull_request_reviews is null
+  - required_pull_request_reviews matches the CCH review gate contract
   - required status checks are strict and include actionlint, validate, test-go
   - force pushes and branch deletion are disabled
 
@@ -118,7 +117,7 @@ pass_check() {
 if jq -e '.required_pull_request_reviews == null' >/dev/null <<<"$json"; then
   pass_check "required_pull_request_reviews is null"
 else
-  fail_check "required_pull_request_reviews must stay null; CCH review gate is harness-review/Codex companion approval"
+  fail_check "required_pull_request_reviews must match the CCH review gate contract"
 fi
 
 if jq -e '.required_status_checks.strict == true' >/dev/null <<<"$json"; then

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -189,6 +189,28 @@ check_release_version_sync() {
   rm -f "$output_file"
 }
 
+check_cch_branch_protection_policy() {
+  if [ -n "${HARNESS_RELEASE_BRANCH_PROTECTION_CMD:-}" ]; then
+    run_optional_command "CCH branch protection policy" "$HARNESS_RELEASE_BRANCH_PROTECTION_CMD"
+    return
+  fi
+
+  if [ ! -x scripts/check-cch-branch-protection-policy.sh ]; then
+    warn "CCH branch protection policy skipped"
+    return
+  fi
+
+  local output_file
+  output_file="$(mktemp)"
+  if bash scripts/check-cch-branch-protection-policy.sh >"$output_file" 2>&1; then
+    pass "CCH branch protection policy"
+  else
+    fail "CCH branch protection policy"
+    sed 's/^/  /' "$output_file"
+  fi
+  rm -f "$output_file"
+}
+
 check_env_and_healthcheck() {
   local env_ok=1
 
@@ -730,6 +752,7 @@ echo "----------------------------------------"
 check_git_clean
 check_changelog
 check_release_version_sync
+check_cch_branch_protection_policy
 check_env_and_healthcheck
 check_runtime_residuals
 check_sprint_contract_schema

--- a/tests/test-cch-branch-protection-policy.sh
+++ b/tests/test-cch-branch-protection-policy.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/check-cch-branch-protection-policy.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  if ! grep -q "$pattern" "$file"; then
+    fail "expected pattern '$pattern' in $file"
+  fi
+}
+
+[ -x "$SCRIPT" ] || fail "missing executable policy script"
+
+cat > "$TMP_DIR/good.json" <<'EOF'
+{
+  "required_pull_request_reviews": null,
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["actionlint", "validate", "test-go"]
+  },
+  "allow_force_pushes": {
+    "enabled": false
+  },
+  "allow_deletions": {
+    "enabled": false
+  }
+}
+EOF
+
+"$SCRIPT" --json "$TMP_DIR/good.json" > "$TMP_DIR/good.out"
+assert_contains "$TMP_DIR/good.out" "CCH branch protection policy: ok"
+
+cat > "$TMP_DIR/review-required.json" <<'EOF'
+{
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1
+  },
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["actionlint", "validate", "test-go"]
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+
+if "$SCRIPT" --json "$TMP_DIR/review-required.json" > "$TMP_DIR/review-required.out" 2>&1; then
+  fail "policy script should reject GitHub human-review enforcement"
+fi
+assert_contains "$TMP_DIR/review-required.out" "required_pull_request_reviews must stay null"
+
+cat > "$TMP_DIR/missing-check.json" <<'EOF'
+{
+  "required_pull_request_reviews": null,
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["actionlint", "validate"]
+  },
+  "allow_force_pushes": {
+    "enabled": false
+  },
+  "allow_deletions": {
+    "enabled": false
+  }
+}
+EOF
+
+if "$SCRIPT" --json "$TMP_DIR/missing-check.json" > "$TMP_DIR/missing-check.out" 2>&1; then
+  fail "policy script should reject missing required status checks"
+fi
+assert_contains "$TMP_DIR/missing-check.out" "required status checks must include test-go"
+
+echo "test-cch-branch-protection-policy: ok"

--- a/tests/test-cch-branch-protection-policy.sh
+++ b/tests/test-cch-branch-protection-policy.sh
@@ -56,9 +56,9 @@ cat > "$TMP_DIR/review-required.json" <<'EOF'
 EOF
 
 if "$SCRIPT" --json "$TMP_DIR/review-required.json" > "$TMP_DIR/review-required.out" 2>&1; then
-  fail "policy script should reject GitHub human-review enforcement"
+  fail "policy script should reject drifted review settings"
 fi
-assert_contains "$TMP_DIR/review-required.out" "required_pull_request_reviews must stay null"
+assert_contains "$TMP_DIR/review-required.out" "required_pull_request_reviews must match the CCH review gate contract"
 
 cat > "$TMP_DIR/missing-check.json" <<'EOF'
 {

--- a/tests/test-cch-branch-protection-policy.sh
+++ b/tests/test-cch-branch-protection-policy.sh
@@ -41,6 +41,26 @@ EOF
 "$SCRIPT" --json "$TMP_DIR/good.json" > "$TMP_DIR/good.out"
 assert_contains "$TMP_DIR/good.out" "CCH branch protection policy: ok"
 
+cat > "$TMP_DIR/good-checks.json" <<'EOF'
+{
+  "required_pull_request_reviews": null,
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [],
+    "checks": [
+      {"context": "actionlint", "app_id": 15368},
+      {"context": "validate", "app_id": 15368},
+      {"context": "test-go", "app_id": 15368}
+    ]
+  },
+  "allow_force_pushes": false,
+  "allow_deletions": false
+}
+EOF
+
+"$SCRIPT" --json "$TMP_DIR/good-checks.json" > "$TMP_DIR/good-checks.out"
+assert_contains "$TMP_DIR/good-checks.out" "CCH branch protection policy: ok"
+
 cat > "$TMP_DIR/review-required.json" <<'EOF'
 {
   "required_pull_request_reviews": {

--- a/tests/test-release-preflight.sh
+++ b/tests/test-release-preflight.sh
@@ -316,6 +316,7 @@ test_preflight_pass_and_fail() {
   HARNESS_RELEASE_PROJECT_ROOT="$repo" \
   HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
   HARNESS_RELEASE_CI_STATUS_CMD='true' \
+  HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
     "$PROJECT_ROOT/scripts/release-preflight.sh" --check-adapters >"$success_output"
 
   assert_contains "$success_output" "\\[PASS\\] working tree clean"
@@ -329,6 +330,7 @@ test_preflight_pass_and_fail() {
   assert_contains "$success_output" "\\[PASS\\] opencode mirror validation"
   assert_contains "$success_output" "\\[PASS\\] skill mirror sync check"
   assert_contains "$success_output" "\\[PASS\\] release mirror drift"
+  assert_contains "$success_output" "\\[PASS\\] CCH branch protection policy"
   assert_contains "$success_output" "\\[PASS\\] codex plugin adapter smoke"
   assert_contains "$success_output" "\\[PASS\\] opencode bootstrap smoke"
   assert_contains "$success_output" "\\[PASS\\] bootstrap skill trigger acceptance gate"
@@ -339,6 +341,7 @@ test_preflight_pass_and_fail() {
   if HARNESS_RELEASE_PROJECT_ROOT="$repo" \
     HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
     HARNESS_RELEASE_CI_STATUS_CMD='true' \
+    HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
       "$PROJECT_ROOT/scripts/release-preflight.sh" --check-adapters >"$failure_output" 2>&1; then
     fail "preflight should fail on dirty tree"
   fi
@@ -352,6 +355,7 @@ test_preflight_pass_and_fail() {
   if HARNESS_RELEASE_PROJECT_ROOT="$invalid_repo" \
     HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
     HARNESS_RELEASE_CI_STATUS_CMD='true' \
+    HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
       "$PROJECT_ROOT/scripts/release-preflight.sh" >"$schema_failure_output" 2>&1; then
     fail "preflight should fail on invalid sprint-contract schema"
   fi
@@ -368,6 +372,7 @@ test_preflight_fails_on_opencode_mirror_drift() {
   if HARNESS_RELEASE_PROJECT_ROOT="$repo" \
     HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
     HARNESS_RELEASE_CI_STATUS_CMD='true' \
+    HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
       "$PROJECT_ROOT/scripts/release-preflight.sh" --check-adapters >"$output" 2>&1; then
     fail "preflight should fail on generated opencode mirror drift"
   fi
@@ -419,6 +424,7 @@ EOF
   HARNESS_RELEASE_PROJECT_ROOT="$repo" \
   HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
   HARNESS_RELEASE_CI_STATUS_CMD='true' \
+  HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
     "$PROJECT_ROOT/scripts/release-preflight.sh" >"$success_output"
 
   assert_contains "$success_output" "\\[PASS\\] release version sync"
@@ -440,6 +446,7 @@ PY
   if HARNESS_RELEASE_PROJECT_ROOT="$repo" \
     HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
     HARNESS_RELEASE_CI_STATUS_CMD='true' \
+    HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
       "$PROJECT_ROOT/scripts/release-preflight.sh" >"$failure_output" 2>&1; then
     fail "preflight should fail on plugin marketplace version mismatch"
   fi
@@ -460,6 +467,7 @@ test_preflight_warns_when_env_is_managed_elsewhere() {
   HARNESS_RELEASE_PROJECT_ROOT="$repo" \
   HARNESS_RELEASE_HEALTHCHECK_CMD='true' \
   HARNESS_RELEASE_CI_STATUS_CMD='true' \
+  HARNESS_RELEASE_BRANCH_PROTECTION_CMD='true' \
     "$PROJECT_ROOT/scripts/release-preflight.sh" >"$output"
 
   assert_contains "$output" "\\[WARN\\] .env missing for .env.example"

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -987,6 +987,12 @@ else
     fail_test "harness-release governance contract failed — 'bash tests/test-harness-release-governance.sh' で詳細確認"
 fi
 
+if bash "$PLUGIN_ROOT/tests/test-cch-branch-protection-policy.sh" > /dev/null 2>&1; then
+    pass_test "CCH branch protection policy は harness-review gate と required checks を固定します"
+else
+    fail_test "CCH branch protection policy contract failed — 'bash tests/test-cch-branch-protection-policy.sh' で詳細確認"
+fi
+
 echo ""
 echo "15. Phase 69 (CC 2.1.133-2.1.142) terminalSequence / hooks 契約"
 echo "----------------------------------------"


### PR DESCRIPTION
## Summary
- add a live CCH branch-protection policy check for release preflight
- fail release preflight if repository review settings drift from the CCH review gate contract
- cover the policy with fixture tests and validate-plugin governance

## Verification
- bash tests/test-cch-branch-protection-policy.sh
- bash scripts/check-cch-branch-protection-policy.sh
- bash -n scripts/check-cch-branch-protection-policy.sh tests/test-cch-branch-protection-policy.sh scripts/release-preflight.sh tests/test-release-preflight.sh tests/validate-plugin.sh
- git diff --check
- bash tests/test-release-preflight.sh
- bash tests/validate-plugin.sh
- bash scripts/release-preflight.sh --dry-run

## Notes
- release-preflight warning about no CI run for this new branch is expected until this PR branch CI completes.
- Source memory: .claude/memory/decisions.md D47 records the CCH review gate branch policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ブランチ保護設定が意図したレビューゲートで置換されるサイレントドリフトを防止するためのプリフライトチェックを追加しました。

* **New Features**
  * CCH ブランチ保護ポリシー検証機能を実装し、リリースプリフライト処理時に自動的に設定を検証するようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chachamaru127/claude-code-harness/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->