### PR TITLE
fix: align harness.toml version with VERSION/plugin.json (4.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`harness.toml` のバージョン同期ずれを修正**: v4.13.1 リリースで `VERSION` と `.claude-plugin/plugin.json` は `4.13.1` に bump されたが `harness.toml` が `4.13.0` のまま残っていた。`harness sync`（`scripts/sync-plugin-cache.sh`）は `harness.toml` から `plugin.json` のバージョンを再生成するため、sync 実行のたびに `plugin.json` が `4.13.0` へ巻き戻り、CI の `validate` ジョブ（`check-consistency.sh` のバージョン一致ゲート）が失敗していた。`harness.toml` を `4.13.1` に揃え、3 点（VERSION / plugin.json / harness.toml）同期を回復。
+
 ## [4.13.1] - 2026-05-29
 
 ### Documentation

--- a/harness.toml
+++ b/harness.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "claude-code-harness"
-version = "4.13.0"
+version = "4.13.1"
 description = "Claude harness - A harness for solo developers (Vibecoders) to handle full-cycle contract development."
 homepage = "https://github.com/Chachamaru127/claude-code-harness"
 repository = "https://github.com/Chachamaru127/claude-code-harness"


### PR DESCRIPTION
## Problem

The v4.13.1 release (PR #176) bumped `VERSION` and `.claude-plugin/plugin.json` to `4.13.1` but left `harness.toml` at `4.13.0`. The project versioning rules require all three to stay in sync.

Because `harness sync` (`scripts/sync-plugin-cache.sh` → `bin/harness sync`) **regenerates `plugin.json`'s version from `harness.toml`**, every sync reverts `plugin.json` to `4.13.0`. The CI `validate` job runs `validate-plugin.sh` (which triggers the sync) and then `check-consistency.sh`, whose version-parity gate then fails on `VERSION=4.13.1` vs `plugin.json=4.13.0`.

This is why the `validate` job is currently **red on `main` and on every open PR branched from it** (e.g. #177, #167).

## Fix

Set `harness.toml` version to `4.13.1`, restoring the 3-file sync.

## Verification

```
# after the fix:
bash scripts/sync-plugin-cache.sh   # plugin.json stays 4.13.1 (no revert)
git diff --stat                     # only harness.toml changed
bash scripts/ci/check-consistency.sh  # ✅ すべてのチェックに合格しました
```

No code behavior change — version metadata only. Recorded under `CHANGELOG.md` `[Unreleased]`.

> Once this merges, open PRs whose `validate` was failing on this gate (#177, #167) should go green after a rebase on `main`.

https://claude.ai/code/session_01MNT1hAQw9AzGapXdEA3BFp

---
_Generated by [Claude Code](https://claude.ai/code/session_01MNT1hAQw9AzGapXdEA3BFp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * バージョン管理における整合性の問題を修正しました。

---

**バージョン:** 4.13.1

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Chachamaru127/claude-code-harness/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->