### PR TITLE
fix(worktree): WorktreeCreate hook prints only the worktree path (lands #168)

### DIFF
--- a/go/internal/hookhandler/worktree_create.go
+++ b/go/internal/hookhandler/worktree_create.go
@@ -159,9 +159,10 @@ func gitWorktreeAdd(repoCWD, path, branch string) error {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = repoCWD
 	if outBytes, err := cmd.CombinedOutput(); err != nil {
-		// Branch may already exist from a prior run; retry without -b so
-		// git checks out the existing branch into the new worktree.
-		retry := exec.Command("git", "worktree", "add", path)
+		// Branch may already exist from a prior run; retry without -b but
+		// name the branch explicitly so git checks out the intended
+		// existing branch (not one derived from the target's basename).
+		retry := exec.Command("git", "worktree", "add", path, branch)
 		retry.Dir = repoCWD
 		if outBytes2, err2 := retry.CombinedOutput(); err2 != nil {
 			return fmt.Errorf("%s / %s: %w",
@@ -201,13 +202,33 @@ func isGitWorktree(path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		return false
 	}
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	// --is-inside-work-tree is true for ANY path inside a checkout, so a repo
+	// subdirectory (or a leftover dir inside the main checkout) would be
+	// misreported as a reusable worktree. A worktree root requires git's
+	// toplevel to equal path itself.
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
 	cmd.Dir = path
 	outBytes, err := cmd.Output()
 	if err != nil {
 		return false
 	}
-	return strings.TrimSpace(string(outBytes)) == "true"
+	return sameDir(strings.TrimSpace(string(outBytes)), path)
+}
+
+// sameDir reports whether two paths resolve to the same directory, accounting
+// for relative paths and symlinks (e.g. macOS /var -> /private/var).
+func sameDir(a, b string) bool {
+	return resolveDir(a) == resolveDir(b)
+}
+
+func resolveDir(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		p = abs
+	}
+	if real, err := filepath.EvalSymlinks(p); err == nil {
+		return real
+	}
+	return filepath.Clean(p)
 }
 
 // initWorktreeState creates .claude/state/ inside the worktree and records

--- a/go/internal/hookhandler/worktree_create.go
+++ b/go/internal/hookhandler/worktree_create.go
@@ -5,87 +5,292 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 )
 
 // worktreeInput is the stdin JSON payload for the WorktreeCreate hook.
+//
+// The Claude Code runtime sends session_id, cwd (the main repo working dir),
+// hook_event_name, and a free-form tool_input map. When the runtime already
+// knows the intended worktree path it surfaces it under tool_input (path /
+// worktreePath). We never assume the worktree exists or does not exist —
+// every field is treated as advisory and verified against the filesystem.
 type worktreeInput struct {
-	SessionID     string `json:"session_id"`
-	CWD           string `json:"cwd"`
-	HookEventName string `json:"hook_event_name"`
+	SessionID     string                 `json:"session_id"`
+	CWD           string                 `json:"cwd"`
+	HookEventName string                 `json:"hook_event_name"`
+	ToolInput     map[string]interface{} `json:"tool_input"`
 }
 
-// worktreeInfo is written to .claude/state/worktree-info.json.
+// worktreeInfo is written to .claude/state/worktree-info.json inside the worktree.
 type worktreeInfo struct {
 	WorkerID  string `json:"worker_id"`
 	CreatedAt string `json:"created_at"`
 	CWD       string `json:"cwd"`
 }
 
-// HandleWorktreeCreate ports scripts/hook-handlers/worktree-create.sh.
+// HandleWorktreeCreate implements the Claude Code WorktreeCreate hook contract.
 //
-// On WorktreeCreate events it:
-//  1. Creates .claude/state/ inside the worktree (cwd).
-//  2. Writes worktree-info.json with worker_id, created_at, and cwd.
+// Per the official spec (https://code.claude.com/docs/en/hooks) this hook
+// "replaces default git behavior": a command hook must ensure the worktree
+// directory exists and then print ONLY that directory path on stdout. A
+// missing path or a non-zero exit aborts worktree creation. Emitting a
+// decision JSON (the legacy behavior) makes the runtime treat the JSON text
+// as a path, which fails with "returned a path that is not a directory".
+//
+// The implementation is deliberately defensive about non-determinism: it does
+// not assume the worktree was already created, nor that it must create one. It
+// resolves a target path, reuses it if it is already a valid git worktree, and
+// otherwise creates it. On any unrecoverable ambiguity it emits nothing, which
+// aborts creation safely rather than corrupting state.
 func HandleWorktreeCreate(in io.Reader, out io.Writer) error {
 	data, err := io.ReadAll(in)
 	if err != nil || len(data) == 0 {
-		return writeWorktreeApprove(out, "WorktreeCreate: no payload")
+		// No payload: nothing we can create. Diagnostics go to stderr —
+		// stdout is reserved for the path — and we defer to the runtime's
+		// default git behavior.
+		fmt.Fprintln(os.Stderr, "[claude-code-harness] worktree-create: no payload; deferring to default git behavior")
+		return nil
 	}
 
 	var input worktreeInput
 	if jsonErr := json.Unmarshal(data, &input); jsonErr != nil {
-		return writeWorktreeApprove(out, "WorktreeCreate: no payload")
+		fmt.Fprintf(os.Stderr, "[claude-code-harness] worktree-create: invalid payload JSON: %v\n", jsonErr)
+		return nil
 	}
 
-	cwd, reason, ok := normalizeWorktreeCreateCWD(input.CWD)
+	repoCWD, reason, ok := normalizeWorktreeCreateCWD(input.CWD)
 	if !ok {
-		return writeWorktreeApprove(out, reason)
+		// Malformed cwd (including the legacy decision-JSON-as-cwd bug).
+		// We cannot safely derive a path; emit nothing on stdout.
+		fmt.Fprintf(os.Stderr, "[claude-code-harness] worktree-create: %s\n", reason)
+		return nil
 	}
 
-	stateDir := worktreeStateDir(cwd)
-	if mkErr := os.MkdirAll(stateDir, 0o755); mkErr != nil {
-		// Non-fatal: log and continue.
-		fmt.Fprintf(os.Stderr, "[claude-code-harness] worktree-create: mkdir %s: %v\n", stateDir, mkErr)
+	target := resolveWorktreePath(input, repoCWD)
+
+	finalPath, createErr := ensureWorktree(repoCWD, target)
+	if createErr != nil {
+		// Creation failed. Per the contract, printing no path aborts
+		// creation — the correct, non-destructive outcome. Log and exit.
+		fmt.Fprintf(os.Stderr, "[claude-code-harness] worktree-create: %v\n", createErr)
+		return nil
+	}
+
+	initWorktreeState(finalPath, input.SessionID)
+
+	// Contract: print ONLY the worktree directory path on stdout.
+	_, err = fmt.Fprintln(out, finalPath)
+	return err
+}
+
+// resolveWorktreePath determines the intended worktree directory without
+// assuming whether it already exists. Preference order:
+//  1. An explicit path the runtime placed in tool_input (path / worktreePath).
+//  2. A deterministic path derived from the repo root + session id.
+func resolveWorktreePath(input worktreeInput, repoCWD string) string {
+	for _, key := range []string{"worktreePath", "path", "worktree_path"} {
+		if raw, ok := input.ToolInput[key]; ok {
+			if s, ok := raw.(string); ok {
+				s = strings.TrimSpace(s)
+				if s != "" && !looksLikeHookDecisionJSON(s) {
+					return absOrSelf(s)
+				}
+			}
+		}
+	}
+
+	slug := sanitizeWorktreeSlug(input.SessionID)
+	if slug == "" {
+		slug = "worker"
+	}
+	return filepath.Join(repoCWD, ".harness-worktrees", slug)
+}
+
+// ensureWorktree guarantees that target is a usable worktree directory rooted
+// in the repo at repoCWD, then returns the path that should be reported.
+//
+// It checks the actual filesystem/git state rather than trusting the payload:
+//   - If target is already a git worktree, it is reused as-is.
+//   - If target exists as a non-empty non-worktree dir, it is reported as-is
+//     (never clobbered) to avoid destroying in-progress user state.
+//   - If target does not exist (or is an empty placeholder), a fresh worktree
+//     is created (origin default branch when available, else HEAD).
+//   - If git reports the path is already registered, that is treated as reuse.
+func ensureWorktree(repoCWD, target string) (string, error) {
+	if isGitWorktree(target) {
+		return target, nil
+	}
+
+	if info, statErr := os.Stat(target); statErr == nil && info.IsDir() {
+		if !dirIsEmpty(target) {
+			return target, nil
+		}
+		// Empty dir: git worktree add refuses a pre-existing path, so
+		// remove the empty placeholder before adding.
+		_ = os.Remove(target)
+	}
+
+	branch := worktreeBranchName(target)
+	if err := gitWorktreeAdd(repoCWD, target, branch); err != nil {
+		// Re-check: a concurrent run or prior registration may already
+		// have produced a valid worktree.
+		if isGitWorktree(target) {
+			return target, nil
+		}
+		return "", fmt.Errorf("git worktree add %q: %w", target, err)
+	}
+	return target, nil
+}
+
+// gitWorktreeAdd creates a worktree at path on a new branch. It prefers the
+// origin default branch as the base ref (matching the harness baseRef:"fresh"
+// SSOT) and falls back to HEAD when origin is unavailable (e.g. offline).
+func gitWorktreeAdd(repoCWD, path, branch string) error {
+	base := originDefaultRef(repoCWD)
+
+	args := []string{"worktree", "add", "-b", branch, path}
+	if base != "" {
+		args = append(args, base)
+	}
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoCWD
+	if outBytes, err := cmd.CombinedOutput(); err != nil {
+		// Branch may already exist from a prior run; retry without -b so
+		// git checks out the existing branch into the new worktree.
+		retry := exec.Command("git", "worktree", "add", path)
+		retry.Dir = repoCWD
+		if outBytes2, err2 := retry.CombinedOutput(); err2 != nil {
+			return fmt.Errorf("%s / %s: %w",
+				strings.TrimSpace(string(outBytes)),
+				strings.TrimSpace(string(outBytes2)), err2)
+		}
+	}
+	return nil
+}
+
+// originDefaultRef returns origin/<default-branch> if it can be resolved,
+// otherwise an empty string (caller falls back to HEAD).
+func originDefaultRef(repoCWD string) string {
+	cmd := exec.Command("git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+	cmd.Dir = repoCWD
+	if outBytes, err := cmd.Output(); err == nil {
+		if ref := strings.TrimSpace(string(outBytes)); ref != "" {
+			return ref
+		}
+	}
+	// Fallback: probe common default branch names on origin.
+	for _, name := range []string{"origin/main", "origin/master"} {
+		verify := exec.Command("git", "rev-parse", "--verify", "--quiet", name)
+		verify.Dir = repoCWD
+		if verify.Run() == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+// isGitWorktree reports whether path is the root of a checked-out git worktree.
+func isGitWorktree(path string) bool {
+	if path == "" {
+		return false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = path
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(outBytes)) == "true"
+}
+
+// initWorktreeState creates .claude/state/ inside the worktree and records
+// worker identity. Best-effort and idempotent — failures are non-fatal.
+func initWorktreeState(worktreePath, sessionID string) {
+	stateDir := worktreeStateDir(worktreePath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "[claude-code-harness] worktree-create: mkdir %s: %v\n", stateDir, err)
+		return
 	}
 
 	info := worktreeInfo{
-		WorkerID:  input.SessionID,
+		WorkerID:  sessionID,
 		CreatedAt: time.Now().UTC().Format(time.RFC3339),
-		CWD:       cwd,
+		CWD:       worktreePath,
 	}
-	infoData, err := json.Marshal(info)
-	if err == nil {
-		infoPath := filepath.Join(stateDir, "worktree-info.json")
-		_ = os.WriteFile(infoPath, append(infoData, '\n'), 0o644)
+	if infoData, err := json.Marshal(info); err == nil {
+		_ = os.WriteFile(filepath.Join(stateDir, "worktree-info.json"), append(infoData, '\n'), 0o644)
 	}
-
-	return writeWorktreeApprove(out, "WorktreeCreate: initialized worktree state")
 }
 
+func worktreeBranchName(path string) string {
+	slug := sanitizeWorktreeSlug(filepath.Base(path))
+	if slug == "" {
+		slug = "worker"
+	}
+	return "harness/worker/" + slug
+}
+
+func dirIsEmpty(path string) bool {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false
+	}
+	return len(entries) == 0
+}
+
+func absOrSelf(p string) string {
+	if abs, err := filepath.Abs(p); err == nil {
+		return abs
+	}
+	return p
+}
+
+// sanitizeWorktreeSlug makes a string safe for use as a branch/dir segment.
+func sanitizeWorktreeSlug(s string) string {
+	r := strings.NewReplacer(
+		" ", "-",
+		"/", "-",
+		"\\", "-",
+		".", "-",
+		":", "-",
+	)
+	return strings.Trim(r.Replace(strings.TrimSpace(s)), "-")
+}
+
+// normalizeWorktreeCreateCWD validates and trims the repo cwd from the payload.
+// It returns the cleaned cwd, a human-readable reason when rejected, and an ok
+// flag. The decision-JSON guard prevents the legacy bug (a decision JSON
+// arriving where a cwd was expected) from ever being treated as a path.
 func normalizeWorktreeCreateCWD(raw string) (string, string, bool) {
 	cwd := strings.TrimSpace(raw)
 	if cwd == "" {
 		return "", "WorktreeCreate: no cwd", false
 	}
 	if looksLikeHookDecisionJSON(cwd) {
-		return "", "WorktreeCreate: invalid cwd", false
+		return "", "WorktreeCreate: invalid cwd (decision JSON)", false
 	}
 	return cwd, "", true
 }
 
-func worktreeStateDir(cwd string) string {
-	return filepath.Join(cwd, ".claude", "state")
+// worktreeStateDir returns the .claude/state directory under base.
+func worktreeStateDir(base string) string {
+	return filepath.Join(base, ".claude", "state")
 }
 
+// looksLikeHookDecisionJSON detects a {"decision":...,"reason":...} object so
+// the legacy decision-JSON-as-cwd bug can never be treated as a path.
 func looksLikeHookDecisionJSON(value string) bool {
 	trimmed := strings.TrimSpace(value)
 	if !strings.HasPrefix(trimmed, "{") {
 		return false
 	}
-
 	var payload map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(trimmed), &payload); err != nil {
 		return false
@@ -93,15 +298,4 @@ func looksLikeHookDecisionJSON(value string) bool {
 	_, hasDecision := payload["decision"]
 	_, hasReason := payload["reason"]
 	return hasDecision && hasReason
-}
-
-// writeWorktreeApprove writes the standard approve decision JSON.
-func writeWorktreeApprove(out io.Writer, reason string) error {
-	resp := map[string]string{"decision": "approve", "reason": reason}
-	data, err := json.Marshal(resp)
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(out, "%s\n", data)
-	return err
 }

--- a/go/internal/hookhandler/worktree_create_test.go
+++ b/go/internal/hookhandler/worktree_create_test.go
@@ -199,9 +199,9 @@ func TestHandleWorktreeCreate_HonorsToolInputPath(t *testing.T) {
 func TestSanitizeWorktreeSlug(t *testing.T) {
 	cases := map[string]string{
 		"worker/abc.def": "worker-abc-def",
-		"  spaced  ":      "spaced",
-		"a:b\\c":          "a-b-c",
-		"":                "",
+		"  spaced  ":     "spaced",
+		"a:b\\c":         "a-b-c",
+		"":               "",
 	}
 	for in, want := range cases {
 		if got := sanitizeWorktreeSlug(in); got != want {

--- a/go/internal/hookhandler/worktree_create_test.go
+++ b/go/internal/hookhandler/worktree_create_test.go
@@ -318,3 +318,50 @@ func TestIsGitWorktree_NonWorktree(t *testing.T) {
 		t.Error("a bare temp dir (not under git) should not be a worktree")
 	}
 }
+
+// A subdirectory of the repo is "inside the work tree" but is NOT a worktree
+// root; it must not be reused as a worktree (would print a path still part of
+// the main checkout). Regression for the --is-inside-work-tree → --show-toplevel fix.
+func TestIsGitWorktree_RepoSubdirNotWorktreeRoot(t *testing.T) {
+	repo := initTestRepo(t)
+	if !isGitWorktree(repo) {
+		t.Fatalf("repo root should be a worktree root: %q", repo)
+	}
+	sub := filepath.Join(repo, "subdir")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if isGitWorktree(sub) {
+		t.Errorf("repo subdir must not be treated as a worktree root: %q", sub)
+	}
+}
+
+// When the target branch already exists, gitWorktreeAdd must retry by checking
+// out that exact branch (not one derived from the directory basename).
+func TestGitWorktreeAdd_ReusesExistingBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	branch := "harness/worker/existing"
+	mk := exec.Command("git", "branch", branch)
+	mk.Dir = repo
+	if out, err := mk.CombinedOutput(); err != nil {
+		t.Fatalf("git branch: %s: %v", out, err)
+	}
+
+	target := filepath.Join(t.TempDir(), "wt-existing")
+	if err := gitWorktreeAdd(repo, target, branch); err != nil {
+		t.Fatalf("gitWorktreeAdd with pre-existing branch: %v", err)
+	}
+	if !isGitWorktree(target) {
+		t.Fatalf("target is not a git worktree: %q", target)
+	}
+
+	cur := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+	cur.Dir = target
+	out, err := cur.Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	if got := strings.TrimSpace(string(out)); got != branch {
+		t.Errorf("worktree checked out %q, want intended branch %q", got, branch)
+	}
+}

--- a/go/internal/hookhandler/worktree_create_test.go
+++ b/go/internal/hookhandler/worktree_create_test.go
@@ -4,151 +4,317 @@ import (
 	"bytes"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-func TestHandleWorktreeCreate_EmptyInput(t *testing.T) {
+// initTestRepo creates a throwaway git repo with one commit and returns its path.
+func initTestRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@test",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@test",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s: %v", args, out, err)
+		}
+	}
+
+	run("git", "init", "-q")
+	run("git", "config", "user.email", "test@test")
+	run("git", "config", "user.name", "test")
+	if err := os.WriteFile(filepath.Join(dir, "README"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	run("git", "add", "README")
+	run("git", "commit", "-q", "-m", "seed")
+	return dir
+}
+
+func TestHandleWorktreeCreate_EmptyInput_EmitsNothing(t *testing.T) {
 	var out bytes.Buffer
 	if err := HandleWorktreeCreate(strings.NewReader(""), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertWorktreeApprove(t, out.String(), "WorktreeCreate: no payload")
+	if strings.TrimSpace(out.String()) != "" {
+		t.Fatalf("expected empty stdout, got %q", out.String())
+	}
 }
 
-func TestHandleWorktreeCreate_InvalidJSON(t *testing.T) {
+func TestHandleWorktreeCreate_InvalidJSON_EmitsNothing(t *testing.T) {
 	var out bytes.Buffer
 	if err := HandleWorktreeCreate(strings.NewReader("not json"), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertWorktreeApprove(t, out.String(), "WorktreeCreate: no payload")
+	if strings.TrimSpace(out.String()) != "" {
+		t.Fatalf("expected empty stdout, got %q", out.String())
+	}
 }
 
-func TestHandleWorktreeCreate_NoCWD(t *testing.T) {
+func TestHandleWorktreeCreate_NoCWD_EmitsNothing(t *testing.T) {
 	var out bytes.Buffer
-	payload := `{"session_id":"s1","cwd":""}`
-	if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
+	if err := HandleWorktreeCreate(strings.NewReader(`{"session_id":"s1","cwd":""}`), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	assertWorktreeApprove(t, out.String(), "WorktreeCreate: no cwd")
+	if strings.TrimSpace(out.String()) != "" {
+		t.Fatalf("expected empty stdout, got %q", out.String())
+	}
 }
 
+// The legacy decision-JSON-as-cwd bug must never be treated as a path.
 func TestHandleWorktreeCreate_RejectsHookDecisionAsCWD(t *testing.T) {
-	dir := t.TempDir()
-	originalWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir temp: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(originalWD)
-	})
-
 	var out bytes.Buffer
 	badCWD := `{"decision":"approve","reason":"WorktreeCreate: initialized worktree state"}`
 	payload := `{"session_id":"worker-json","cwd":` + strconv.Quote(badCWD) + `}`
 	if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-
-	assertWorktreeApprove(t, out.String(), "WorktreeCreate: invalid cwd")
-	if _, err := os.Stat(filepath.Join(dir, badCWD)); !os.IsNotExist(err) {
+	if strings.TrimSpace(out.String()) != "" {
+		t.Fatalf("decision JSON cwd produced output %q", out.String())
+	}
+	if _, err := os.Stat(badCWD); !os.IsNotExist(err) {
 		t.Fatalf("hook decision JSON was treated as a directory: stat err=%v", err)
 	}
 }
 
-func TestHandleWorktreeCreate_CreatesStateDir(t *testing.T) {
-	dir := t.TempDir()
+// Contract: with a valid repo cwd, the hook creates a worktree and prints ONLY
+// its path on stdout (not a JSON object).
+func TestHandleWorktreeCreate_CreatesWorktreeAndPrintsPath(t *testing.T) {
+	repo := initTestRepo(t)
 
 	var out bytes.Buffer
-	payload := `{"session_id":"worker-123","cwd":"` + dir + `"}`
+	payload := `{"session_id":"worker-123","cwd":` + strconv.Quote(repo) + `}`
 	if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertWorktreeApprove(t, out.String(), "WorktreeCreate: initialized worktree state")
+	printed := strings.TrimSpace(out.String())
+	if printed == "" {
+		t.Fatal("expected a worktree path on stdout, got empty")
+	}
+	if strings.HasPrefix(printed, "{") {
+		t.Fatalf("stdout must be a path, not JSON: %q", printed)
+	}
 
-	// .claude/state/ must be created.
-	stateDir := filepath.Join(dir, ".claude", "state")
-	if info, err := os.Stat(stateDir); err != nil || !info.IsDir() {
-		t.Errorf(".claude/state/ was not created at %s", stateDir)
+	info, err := os.Stat(printed)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("printed path is not a directory: %q (err=%v)", printed, err)
+	}
+	if !isGitWorktree(printed) {
+		t.Fatalf("printed path is not a git worktree: %q", printed)
+	}
+
+	stateDir := filepath.Join(printed, ".claude", "state")
+	if si, err := os.Stat(stateDir); err != nil || !si.IsDir() {
+		t.Errorf(".claude/state/ not created at %s", stateDir)
 	}
 }
 
 func TestHandleWorktreeCreate_WritesWorktreeInfo(t *testing.T) {
-	dir := t.TempDir()
+	repo := initTestRepo(t)
 
 	var out bytes.Buffer
-	payload := `{"session_id":"worker-xyz","cwd":"` + dir + `"}`
+	payload := `{"session_id":"worker-xyz","cwd":` + strconv.Quote(repo) + `}`
 	if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	worktreePath := strings.TrimSpace(out.String())
 
-	infoPath := filepath.Join(dir, ".claude", "state", "worktree-info.json")
+	infoPath := filepath.Join(worktreePath, ".claude", "state", "worktree-info.json")
 	data, err := os.ReadFile(infoPath)
 	if err != nil {
 		t.Fatalf("worktree-info.json not created: %v", err)
 	}
-
 	var info worktreeInfo
 	if err := json.Unmarshal(bytes.TrimSpace(data), &info); err != nil {
-		t.Fatalf("worktree-info.json is not valid JSON: %v\n%s", err, data)
+		t.Fatalf("worktree-info.json invalid JSON: %v\n%s", err, data)
 	}
-
 	if info.WorkerID != "worker-xyz" {
 		t.Errorf("WorkerID = %q, want worker-xyz", info.WorkerID)
 	}
-	if info.CWD != dir {
-		t.Errorf("CWD = %q, want %q", info.CWD, dir)
+	if info.CWD != worktreePath {
+		t.Errorf("CWD = %q, want %q", info.CWD, worktreePath)
 	}
 	if info.CreatedAt == "" {
 		t.Error("CreatedAt is empty")
 	}
 }
 
+// Idempotency: a second call for the same session reuses the existing worktree
+// and prints the same path without failing.
 func TestHandleWorktreeCreate_Idempotent(t *testing.T) {
-	dir := t.TempDir()
+	repo := initTestRepo(t)
+	payload := `{"session_id":"s-idem","cwd":` + strconv.Quote(repo) + `}`
 
-	// Run twice — second call should not fail even though state dir already exists.
-	for i := 0; i < 2; i++ {
-		var out bytes.Buffer
-		payload := `{"session_id":"s","cwd":"` + dir + `"}`
-		if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
-			t.Fatalf("call %d: unexpected error: %v", i+1, err)
-		}
-		assertWorktreeApprove(t, out.String(), "WorktreeCreate: initialized worktree state")
+	var first bytes.Buffer
+	if err := HandleWorktreeCreate(strings.NewReader(payload), &first); err != nil {
+		t.Fatalf("call 1: %v", err)
+	}
+	firstPath := strings.TrimSpace(first.String())
+	if firstPath == "" {
+		t.Fatal("call 1 produced no path")
+	}
+
+	var second bytes.Buffer
+	if err := HandleWorktreeCreate(strings.NewReader(payload), &second); err != nil {
+		t.Fatalf("call 2: %v", err)
+	}
+	secondPath := strings.TrimSpace(second.String())
+	if secondPath != firstPath {
+		t.Fatalf("idempotency broken: %q != %q", secondPath, firstPath)
+	}
+	if !isGitWorktree(secondPath) {
+		t.Fatalf("reused path is not a worktree: %q", secondPath)
 	}
 }
 
-func TestWorktreeStateDir_UsesPlatformJoin(t *testing.T) {
-	dir := filepath.Join("repo", "worker-a")
-	got := worktreeStateDir(dir)
-	want := filepath.Join(dir, ".claude", "state")
+// An explicit worktree path in tool_input is honored.
+func TestHandleWorktreeCreate_HonorsToolInputPath(t *testing.T) {
+	repo := initTestRepo(t)
+	want := filepath.Join(repo, "custom-wt")
+
+	payload := `{"session_id":"s","cwd":` + strconv.Quote(repo) +
+		`,"tool_input":{"worktreePath":` + strconv.Quote(want) + `}}`
+	var out bytes.Buffer
+	if err := HandleWorktreeCreate(strings.NewReader(payload), &out); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := strings.TrimSpace(out.String())
 	if got != want {
-		t.Fatalf("worktreeStateDir() = %q, want %q", got, want)
+		t.Fatalf("path = %q, want %q", got, want)
+	}
+	if !isGitWorktree(got) {
+		t.Fatalf("not a worktree: %q", got)
 	}
 }
 
-// assertWorktreeApprove verifies the output is a valid JSON approve response
-// with the expected reason.
-func assertWorktreeApprove(t *testing.T, output, expectedReason string) {
-	t.Helper()
-	output = strings.TrimSpace(output)
-	if output == "" {
-		t.Fatal("expected approve JSON, got empty output")
+func TestSanitizeWorktreeSlug(t *testing.T) {
+	cases := map[string]string{
+		"worker/abc.def": "worker-abc-def",
+		"  spaced  ":      "spaced",
+		"a:b\\c":          "a-b-c",
+		"":                "",
 	}
-	var resp map[string]string
-	if err := json.Unmarshal([]byte(output), &resp); err != nil {
-		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, output)
+	for in, want := range cases {
+		if got := sanitizeWorktreeSlug(in); got != want {
+			t.Errorf("sanitizeWorktreeSlug(%q) = %q, want %q", in, got, want)
+		}
 	}
-	if resp["decision"] != "approve" {
-		t.Errorf("decision = %q, want approve", resp["decision"])
+}
+
+func TestNormalizeWorktreeCreateCWD(t *testing.T) {
+	if _, _, ok := normalizeWorktreeCreateCWD(""); ok {
+		t.Error("empty cwd should be rejected")
 	}
-	if expectedReason != "" && resp["reason"] != expectedReason {
-		t.Errorf("reason = %q, want %q", resp["reason"], expectedReason)
+	if _, _, ok := normalizeWorktreeCreateCWD("   "); ok {
+		t.Error("blank cwd should be rejected")
+	}
+	if _, reason, ok := normalizeWorktreeCreateCWD(`{"decision":"approve","reason":"x"}`); ok {
+		t.Errorf("decision JSON cwd should be rejected (reason=%q)", reason)
+	}
+	got, reason, ok := normalizeWorktreeCreateCWD("  /repo/path  ")
+	if !ok {
+		t.Fatalf("valid cwd rejected: reason=%q", reason)
+	}
+	if got != "/repo/path" {
+		t.Errorf("cwd = %q, want trimmed /repo/path", got)
+	}
+}
+
+func TestWorktreeStateDir(t *testing.T) {
+	got := worktreeStateDir(filepath.Join("a", "b"))
+	want := filepath.Join("a", "b", ".claude", "state")
+	if got != want {
+		t.Errorf("worktreeStateDir = %q, want %q", got, want)
+	}
+}
+
+func TestWorktreeBranchName(t *testing.T) {
+	cases := map[string]string{
+		filepath.Join("repo", ".harness-worktrees", "worker-123"): "harness/worker/worker-123",
+		filepath.Join("x", "abc.def"):                             "harness/worker/abc-def",
+	}
+	for in, want := range cases {
+		if got := worktreeBranchName(in); got != want {
+			t.Errorf("worktreeBranchName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// A base that sanitizes to empty falls back to "worker".
+	if got := worktreeBranchName(string(filepath.Separator)); got != "harness/worker/worker" {
+		t.Errorf("worktreeBranchName(root) = %q, want harness/worker/worker", got)
+	}
+}
+
+func TestDirIsEmpty(t *testing.T) {
+	empty := t.TempDir()
+	if !dirIsEmpty(empty) {
+		t.Error("fresh temp dir should report empty")
+	}
+	if err := os.WriteFile(filepath.Join(empty, "f"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if dirIsEmpty(empty) {
+		t.Error("dir with a file should not report empty")
+	}
+	if dirIsEmpty(filepath.Join(empty, "missing")) {
+		t.Error("missing dir should report false (not empty)")
+	}
+}
+
+func TestAbsOrSelf(t *testing.T) {
+	abs := filepath.Join(string(filepath.Separator), "already", "abs")
+	if got := absOrSelf(abs); got != abs {
+		t.Errorf("absOrSelf(%q) = %q, want unchanged", abs, got)
+	}
+	if got := absOrSelf(filepath.Join("rel", "path")); !filepath.IsAbs(got) {
+		t.Errorf("absOrSelf(rel/path) = %q, want absolute", got)
+	}
+}
+
+func TestOriginDefaultRef(t *testing.T) {
+	repo := initTestRepo(t)
+
+	// No origin remote-tracking refs yet → empty (caller falls back to HEAD).
+	if got := originDefaultRef(repo); got != "" {
+		t.Errorf("originDefaultRef without origin = %q, want empty", got)
+	}
+
+	// Simulate an origin/main remote-tracking ref; the probe must find it.
+	ref := exec.Command("git", "update-ref", "refs/remotes/origin/main", "HEAD")
+	ref.Dir = repo
+	if out, err := ref.CombinedOutput(); err != nil {
+		t.Fatalf("update-ref: %s: %v", out, err)
+	}
+	if got := originDefaultRef(repo); got != "origin/main" {
+		t.Errorf("originDefaultRef with origin/main = %q, want origin/main", got)
+	}
+}
+
+func TestGitWorktreeAdd(t *testing.T) {
+	repo := initTestRepo(t)
+	target := filepath.Join(t.TempDir(), "wt-add")
+
+	if err := gitWorktreeAdd(repo, target, "harness/worker/test-add"); err != nil {
+		t.Fatalf("gitWorktreeAdd: %v", err)
+	}
+	if !isGitWorktree(target) {
+		t.Fatalf("target is not a git worktree: %q", target)
+	}
+}
+
+func TestIsGitWorktree_NonWorktree(t *testing.T) {
+	if isGitWorktree("") {
+		t.Error("empty path should not be a worktree")
+	}
+	if isGitWorktree(t.TempDir()) {
+		t.Error("a bare temp dir (not under git) should not be a worktree")
 	}
 }

--- a/scripts/hook-handlers/worktree-create.sh
+++ b/scripts/hook-handlers/worktree-create.sh
@@ -97,9 +97,21 @@ else
   TARGET="${CWD}/.harness-worktrees/${SLUG}"
 fi
 
+# resolve_dir canonicalizes an existing directory (follows symlinks) without
+# changing the caller's working directory (uses a subshell).
+resolve_dir() {
+  ( cd "$1" 2>/dev/null && pwd -P ) || printf '%s' "$1"
+}
+
 is_git_worktree() {
   [ -e "$1" ] || return 1
-  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+  # --is-inside-work-tree is true for ANY path inside a checkout, so a repo
+  # subdirectory would be misreported as a reusable worktree. Require git's
+  # toplevel to equal the path itself (a worktree root).
+  local top
+  top="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [ -n "${top}" ] || return 1
+  [ "$(resolve_dir "${top}")" = "$(resolve_dir "$1")" ]
 }
 
 origin_default_ref() {
@@ -127,10 +139,10 @@ if ! is_git_worktree "${TARGET}"; then
     BASE="$(origin_default_ref)"
     if [ -n "${BASE}" ]; then
       git -C "${CWD}" worktree add -b "${BRANCH}" "${TARGET}" "${BASE}" >/dev/null 2>&1 \
-        || git -C "${CWD}" worktree add "${TARGET}" >/dev/null 2>&1 || true
+        || git -C "${CWD}" worktree add "${TARGET}" "${BRANCH}" >/dev/null 2>&1 || true
     else
       git -C "${CWD}" worktree add -b "${BRANCH}" "${TARGET}" >/dev/null 2>&1 \
-        || git -C "${CWD}" worktree add "${TARGET}" >/dev/null 2>&1 || true
+        || git -C "${CWD}" worktree add "${TARGET}" "${BRANCH}" >/dev/null 2>&1 || true
     fi
 
     # If creation failed, abort safely (emit nothing).

--- a/scripts/hook-handlers/worktree-create.sh
+++ b/scripts/hook-handlers/worktree-create.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-# worktree-create.sh — WorktreeCreate hook handler
-# Breezing 並列ワーカー用の worktree 環境を初期化する
+# worktree-create.sh — WorktreeCreate hook handler (shell fallback)
 #
-# 入力 (stdin JSON):
-#   session_id, cwd, hook_event_name
+# Claude Code WorktreeCreate hook contract
+# (https://code.claude.com/docs/en/hooks):
+#   - This hook "replaces default git behavior".
+#   - A command hook must ensure the worktree directory exists and print ONLY
+#     that directory path on stdout.
+#   - Missing path or non-zero exit aborts worktree creation.
 #
-# 設計: WorktreeCreate/Remove は worktree 固有リソースのみ担当
-#       SessionEnd はセッション全体リソースを担当（分離設計）
+# Emitting a decision JSON (the legacy behavior) makes the runtime treat the
+# JSON text as a path → "returned a path that is not a directory".
+#
+# Defensive about non-determinism: never assume the worktree exists or does
+# not. Reuse a valid existing worktree; otherwise create one. On unrecoverable
+# ambiguity, emit nothing (aborts creation safely) rather than corrupt state.
+#
+# 入力 (stdin JSON): session_id, cwd, hook_event_name, tool_input
 
 set -euo pipefail
 
@@ -16,119 +25,141 @@ if [ ! -t 0 ]; then
   INPUT="$(cat 2>/dev/null)"
 fi
 
-# ペイロードが空の場合はスキップ
-if [ -z "${INPUT}" ]; then
-  echo '{"decision":"approve","reason":"WorktreeCreate: no payload"}'
-  exit 0
-fi
-
-# === フィールド抽出 ===
-SESSION_ID=""
-CWD=""
+# No payload: emit nothing, let the runtime fall back to default git behavior.
+[ -z "${INPUT}" ] && exit 0
 
 looks_like_hook_decision_json() {
   local value
   value="$(printf '%s' "$1" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
-
   case "${value}" in
     \{*) ;;
     *) return 1 ;;
   esac
-
   if command -v jq >/dev/null 2>&1; then
-    printf '%s' "${value}" \
-      | jq -e 'type == "object" and has("decision") and has("reason")' >/dev/null 2>&1
+    printf '%s' "${value}" | jq -e 'type == "object" and has("decision") and has("reason")' >/dev/null 2>&1
     return $?
   fi
-
-  if command -v python3 >/dev/null 2>&1; then
-    printf '%s' "${value}" | python3 -c '
-import json
-import sys
-
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    raise SystemExit(1)
-
-raise SystemExit(0 if isinstance(data, dict) and "decision" in data and "reason" in data else 1)
-' >/dev/null 2>&1
-    return $?
-  fi
-
   case "${value}" in
     *'"decision"'*'"reason"'*) return 0 ;;
     *) return 1 ;;
   esac
 }
 
+# === フィールド抽出 ===
+SESSION_ID=""
+CWD=""
+TOOL_WORKTREE_PATH=""
+
 if command -v jq >/dev/null 2>&1; then
-  _jq_parsed="$(echo "${INPUT}" | jq -r '[
+  _parsed="$(printf '%s' "${INPUT}" | jq -r '[
     (.session_id // ""),
-    (.cwd // "")
-  ] | @tsv' 2>/dev/null)"
-  if [ -n "${_jq_parsed}" ]; then
-    IFS=$'\t' read -r SESSION_ID CWD <<< "${_jq_parsed}"
+    (.cwd // ""),
+    (.tool_input.worktreePath // .tool_input.path // .tool_input.worktree_path // "")
+  ] | @tsv' 2>/dev/null || true)"
+  if [ -n "${_parsed}" ]; then
+    IFS=$'\t' read -r SESSION_ID CWD TOOL_WORKTREE_PATH <<< "${_parsed}"
   fi
-  unset _jq_parsed
+  unset _parsed
 elif command -v python3 >/dev/null 2>&1; then
-  _parsed="$(echo "${INPUT}" | python3 -c "
+  _parsed="$(printf '%s' "${INPUT}" | python3 -c "
 import sys, json
 try:
     d = json.load(sys.stdin)
+    ti = d.get('tool_input') or {}
     print(d.get('session_id', ''))
     print(d.get('cwd', ''))
-except:
-    print('')
-    print('')
-" 2>/dev/null)"
-  SESSION_ID="$(echo "${_parsed}" | sed -n '1p')"
-  CWD="$(echo "${_parsed}" | sed -n '2p')"
+    print(ti.get('worktreePath') or ti.get('path') or ti.get('worktree_path') or '')
+except Exception:
+    print(''); print(''); print('')
+" 2>/dev/null || true)"
+  SESSION_ID="$(printf '%s' "${_parsed}" | sed -n '1p')"
+  CWD="$(printf '%s' "${_parsed}" | sed -n '2p')"
+  TOOL_WORKTREE_PATH="$(printf '%s' "${_parsed}" | sed -n '3p')"
+  unset _parsed
 fi
 
-if [ -z "${CWD}" ]; then
-  echo '{"decision":"approve","reason":"WorktreeCreate: no cwd"}'
-  exit 0
-fi
-
+# Malformed cwd (empty or the legacy decision-JSON-as-cwd bug): abort safely.
+[ -z "${CWD}" ] && exit 0
 if looks_like_hook_decision_json "${CWD}"; then
-  echo '{"decision":"approve","reason":"WorktreeCreate: invalid cwd"}'
   exit 0
 fi
 
-# === worktree 内に .claude/state/ ディレクトリを確保 ===
-WORKTREE_STATE_DIR="${CWD}/.claude/state"
-mkdir -p "${WORKTREE_STATE_DIR}" 2>/dev/null || true
+# === worktree パスを決定 ===
+sanitize_slug() {
+  printf '%s' "$1" | sed 's#[ /\\.:]#-#g; s/^-*//; s/-*$//'
+}
 
-# === ワーカー ID を記録（Breezing チームでの識別用） ===
+if [ -n "${TOOL_WORKTREE_PATH}" ] && ! looks_like_hook_decision_json "${TOOL_WORKTREE_PATH}"; then
+  TARGET="${TOOL_WORKTREE_PATH}"
+else
+  SLUG="$(sanitize_slug "${SESSION_ID}")"
+  [ -z "${SLUG}" ] && SLUG="worker"
+  TARGET="${CWD}/.harness-worktrees/${SLUG}"
+fi
+
+is_git_worktree() {
+  [ -e "$1" ] || return 1
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+origin_default_ref() {
+  local ref
+  ref="$(git -C "${CWD}" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null || true)"
+  if [ -n "${ref}" ]; then printf '%s' "${ref}"; return 0; fi
+  for name in origin/main origin/master; do
+    if git -C "${CWD}" rev-parse --verify --quiet "${name}" >/dev/null 2>&1; then
+      printf '%s' "${name}"; return 0
+    fi
+  done
+  printf ''
+}
+
+# === worktree を確保（reuse or create）===
+if ! is_git_worktree "${TARGET}"; then
+  # Pre-existing non-empty non-worktree dir: never clobber, report as-is.
+  if [ -d "${TARGET}" ] && [ -n "$(ls -A "${TARGET}" 2>/dev/null)" ]; then
+    : # fall through and report TARGET below
+  else
+    # Empty placeholder would block `git worktree add`; remove it.
+    [ -d "${TARGET}" ] && rmdir "${TARGET}" 2>/dev/null || true
+
+    BRANCH="harness/worker/$(sanitize_slug "$(basename "${TARGET}")")"
+    BASE="$(origin_default_ref)"
+    if [ -n "${BASE}" ]; then
+      git -C "${CWD}" worktree add -b "${BRANCH}" "${TARGET}" "${BASE}" >/dev/null 2>&1 \
+        || git -C "${CWD}" worktree add "${TARGET}" >/dev/null 2>&1 || true
+    else
+      git -C "${CWD}" worktree add -b "${BRANCH}" "${TARGET}" >/dev/null 2>&1 \
+        || git -C "${CWD}" worktree add "${TARGET}" >/dev/null 2>&1 || true
+    fi
+
+    # If creation failed, abort safely (emit nothing).
+    if ! is_git_worktree "${TARGET}"; then
+      echo "[claude-code-harness] worktree-create: failed to create ${TARGET}" >&2
+      exit 0
+    fi
+  fi
+fi
+
+# === worktree 内に .claude/state/ を初期化（best-effort, idempotent）===
+WORKTREE_STATE_DIR="${TARGET}/.claude/state"
+mkdir -p "${WORKTREE_STATE_DIR}" 2>/dev/null || true
 WORKTREE_INFO_FILE="${WORKTREE_STATE_DIR}/worktree-info.json"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 if command -v jq >/dev/null 2>&1; then
   jq -nc \
     --arg worker_id "${SESSION_ID}" \
-    --arg created_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    --arg cwd "${CWD}" \
+    --arg created_at "${CREATED_AT}" \
+    --arg cwd "${TARGET}" \
     '{"worker_id":$worker_id,"created_at":$created_at,"cwd":$cwd}' \
     > "${WORKTREE_INFO_FILE}" 2>/dev/null || true
-elif command -v python3 >/dev/null 2>&1; then
-  python3 -c "
-import json, sys
-print(json.dumps({
-    'worker_id': sys.argv[1],
-    'created_at': sys.argv[2],
-    'cwd': sys.argv[3]
-}, ensure_ascii=False))
-" "${SESSION_ID}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${CWD}" \
-    > "${WORKTREE_INFO_FILE}" 2>/dev/null || true
 else
-  # フォールバック: シンプルな JSON 書き出し
   printf '{"worker_id":"%s","created_at":"%s","cwd":"%s"}\n' \
-    "${SESSION_ID//\"/\\\"}" \
-    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-    "${CWD//\"/\\\"}" \
+    "${SESSION_ID//\"/\\\"}" "${CREATED_AT}" "${TARGET//\"/\\\"}" \
     > "${WORKTREE_INFO_FILE}" 2>/dev/null || true
 fi
 
-# === レスポンス ===
-echo '{"decision":"approve","reason":"WorktreeCreate: initialized worktree state"}'
+# === Contract: print ONLY the worktree directory path on stdout ===
+printf '%s\n' "${TARGET}"
 exit 0

--- a/tests/test-windows-worktree-support.sh
+++ b/tests/test-windows-worktree-support.sh
@@ -26,7 +26,7 @@ grep_file 'harness-\$\{OS\}-\$\{ARCH\}\$\{EXT\}' "bin/harness" "shim resolves su
 grep_file '"windows/amd64"' "go/scripts/build-all.sh" "build-all includes Windows amd64"
 grep_file '\.exe' "go/scripts/build-all.sh" "build-all emits Windows .exe artifact"
 
-grep_file 'filepath\.Join\(cwd, "\.claude", "state"\)' "go/internal/hookhandler/worktree_create.go" "WorktreeCreate uses platform path joining"
+grep_file 'filepath\.Join\([A-Za-z]+, "\.claude", "state"\)' "go/internal/hookhandler/worktree_create.go" "WorktreeCreate uses platform path joining"
 grep_file 'looksLikeHookDecisionJSON' "go/internal/hookhandler/worktree_create.go" "WorktreeCreate rejects hook decision JSON as cwd"
 grep_file '//go:build windows' "go/internal/hookhandler/file_lock_windows.go" "Windows build has a file-lock fallback"
 grep_file 'file lock unsupported on windows' "go/internal/hookhandler/file_lock_windows.go" "Windows build avoids syscall.Flock"

--- a/tests/test-worktree-create-hook.sh
+++ b/tests/test-worktree-create-hook.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # Regression checks for the WorktreeCreate shell hook.
+#
+# Contract (https://code.claude.com/docs/en/hooks): the hook ensures the
+# worktree directory exists and prints ONLY that path on stdout. Malformed
+# input emits nothing (aborts creation safely).
 
 set -euo pipefail
 
@@ -13,56 +17,67 @@ fail() {
   exit 1
 }
 
-json_get() {
-  local file="$1"
-  local key="$2"
-  python3 - "$file" "$key" <<'PY'
-import json
-import sys
-
-with open(sys.argv[1], "r", encoding="utf-8") as fh:
-    data = json.load(fh)
-print(data.get(sys.argv[2], ""))
-PY
+json_str() {
+  python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "$1"
 }
 
 run_hook() {
-  local payload="$1"
-  local output_file="$2"
-  (
-    cd "${TMP_DIR}"
-    printf '%s' "${payload}" | bash "${HOOK}"
-  ) >"${output_file}"
+  local payload="$1" output_file="$2" dir="${3:-${TMP_DIR}}"
+  ( cd "${dir}" && printf '%s' "${payload}" | bash "${HOOK}" ) >"${output_file}" 2>/dev/null || true
 }
 
+# --- A throwaway git repo so `git worktree add` works ---
+REPO="${TMP_DIR}/repo"
+mkdir -p "${REPO}"
+(
+  cd "${REPO}"
+  git init -q
+  git config user.email test@test
+  git config user.name test
+  echo seed > README
+  git add README
+  git commit -qm seed
+)
+
+# === 1. decision-JSON-as-cwd must NOT be treated as a path, emits nothing ===
 INVALID_CWD='{"decision":"approve","reason":"WorktreeCreate: initialized worktree state"}'
 INVALID_OUT="${TMP_DIR}/invalid.out"
-run_hook "{\"session_id\":\"worker-json\",\"cwd\":$(python3 -c 'import json,sys; print(json.dumps(sys.argv[1]))' "${INVALID_CWD}")}" "${INVALID_OUT}"
-
-[ "$(json_get "${INVALID_OUT}" decision)" = "approve" ] || fail "invalid cwd did not approve/no-op"
-[ "$(json_get "${INVALID_OUT}" reason)" = "WorktreeCreate: invalid cwd" ] || fail "invalid cwd reason mismatch"
+run_hook "{\"session_id\":\"worker-json\",\"cwd\":$(json_str "${INVALID_CWD}")}" "${INVALID_OUT}"
+[ ! -s "${INVALID_OUT}" ] || fail "invalid cwd produced output: $(cat "${INVALID_OUT}")"
 [ ! -e "${TMP_DIR}/${INVALID_CWD}" ] || fail "hook decision JSON was treated as a directory"
 
-REAL_CWD="${TMP_DIR}/real-worktree"
-mkdir -p "${REAL_CWD}"
+# === 2. empty cwd emits nothing ===
+EMPTY_OUT="${TMP_DIR}/empty.out"
+run_hook '{"session_id":"s","cwd":""}' "${EMPTY_OUT}"
+[ ! -s "${EMPTY_OUT}" ] || fail "empty cwd produced output: $(cat "${EMPTY_OUT}")"
+
+# === 3. valid repo cwd → creates worktree, prints ONLY the path ===
 REAL_OUT="${TMP_DIR}/real.out"
-run_hook "{\"session_id\":\"worker-123\",\"cwd\":\"${REAL_CWD}\"}" "${REAL_OUT}"
+run_hook "{\"session_id\":\"worker-123\",\"cwd\":$(json_str "${REPO}")}" "${REAL_OUT}" "${REPO}"
+PRINTED="$(tr -d '\n' < "${REAL_OUT}")"
+[ -n "${PRINTED}" ] || fail "valid cwd produced no path"
+case "${PRINTED}" in
+  \{*) fail "stdout must be a path, not JSON: ${PRINTED}" ;;
+esac
+[ -d "${PRINTED}" ] || fail "printed path is not a directory: ${PRINTED}"
+git -C "${PRINTED}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "printed path is not a git worktree: ${PRINTED}"
+[ -d "${PRINTED}/.claude/state" ] || fail "state dir not created in worktree"
+[ -f "${PRINTED}/.claude/state/worktree-info.json" ] || fail "worktree-info.json not created"
 
-[ "$(json_get "${REAL_OUT}" decision)" = "approve" ] || fail "real cwd did not approve"
-[ "$(json_get "${REAL_OUT}" reason)" = "WorktreeCreate: initialized worktree state" ] || fail "real cwd reason mismatch"
-[ -d "${REAL_CWD}/.claude/state" ] || fail "real cwd state dir was not created"
-[ -f "${REAL_CWD}/.claude/state/worktree-info.json" ] || fail "worktree-info.json was not created"
-
-python3 - "${REAL_CWD}/.claude/state/worktree-info.json" <<'PY'
-import json
-import sys
-
+python3 - "${PRINTED}/.claude/state/worktree-info.json" <<'PY'
+import json, sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     data = json.load(fh)
 if data.get("worker_id") != "worker-123":
     raise SystemExit("worker_id mismatch")
-if data.get("cwd") == "":
+if not data.get("cwd"):
     raise SystemExit("cwd missing")
 PY
 
-echo "PASS: WorktreeCreate shell hook rejects decision JSON cwd and initializes real cwd"
+# === 4. idempotent: second call reuses, prints the same path ===
+REAL_OUT2="${TMP_DIR}/real2.out"
+run_hook "{\"session_id\":\"worker-123\",\"cwd\":$(json_str "${REPO}")}" "${REAL_OUT2}" "${REPO}"
+PRINTED2="$(tr -d '\n' < "${REAL_OUT2}")"
+[ "${PRINTED2}" = "${PRINTED}" ] || fail "idempotency broken: ${PRINTED2} != ${PRINTED}"
+
+echo "PASS: WorktreeCreate shell hook creates worktree, prints path, idempotent, rejects decision JSON"


### PR DESCRIPTION
## What this is

This lands **#168** (by @aryrabelo) on top of the current `main`, plus the two fixes its CI runs surfaced. The original author's two commits are cherry-picked unchanged, so authorship is preserved.

#168's own CI was red on two jobs; both were real and are fixed here:

| Job | Failing step | Root cause | Fix |
|-----|--------------|-----------|-----|
| `test-go` | `test-format-lint.sh` (gofmt) | `worktree_create_test.go` map literal was not gofmt-aligned | `gofmt -w` the test file |
| `validate` | `test-windows-worktree-support.sh` | A pre-existing main test grepped for the literal `filepath.Join(cwd, ".claude", "state")`; #168 refactored that inline join into the `worktreeStateDir(base)` helper, so the literal no longer matched | Update the grep to `filepath.Join([A-Za-z]+, ".claude", "state")` — still asserts platform-safe joining of the `.claude`/`state` segments, just tolerant of the variable rename |

The `test-windows-worktree-support.sh` change keeps the test's verification intent intact (Windows-safe path joining via `filepath.Join`, not hardcoded separators); it only follows the `cwd` → `base` rename from the refactor.

## Original change (from #168)

The `WorktreeCreate` hook previously emitted decision JSON on stdout. The Claude Code runtime treats this hook as a replacement for default git worktree behavior and expects **only the worktree path** on stdout; reading JSON as a path aborted worktree creation ("returned a path that is not a directory"), breaking agent-isolation / breezing worker spawns. The Go handler and shell fallback are rewritten to resolve/reuse/create the worktree, init `.claude/state/`, print only the path on stdout (diagnostics → stderr), with a `looksLikeHookDecisionJSON` guard against the legacy bug.

## Local verification (against current main)

- `go build ./cmd/harness/`, `go test ./...`, `go vet ./...` — all exit 0
- `gofmt -l go/` — clean
- `tests/test-format-lint.sh` — PASS
- `tests/test-windows-worktree-support.sh` — PASS

(`validate-plugin.sh` shows 2 unrelated failures locally — `test-reenter-worktree-json.sh` / `test-codex-primary-environment-guard.sh` — caused by this sandbox's commit-signing server, identical on bare `main`; they pass on GitHub CI.)

Closes #168.

https://claude.ai/code/session_01Mqs4LaZKJ2uSMW94FiyRKu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mqs4LaZKJ2uSMW94FiyRKu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Refactor**
  * ワークツリー作成フックの出力形式をシンプル化。標準出力にはディレクトリパスのみを出力するように変更。ワークツリーの状態情報は `.claude/state/worktree-info.json` に記録。

* **Bug Fixes**
  * 不正な入力（空入力、無効なJSON）に対するエラーハンドリングを強化。既存のワークツリーの再利用と新規作成の判定ロジックを改善。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->