### PR TITLE
fix(cursor-do): close 4 initial-use friction points (Issue #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/cursor:ask` / `/cursor:do` 初回利用の摩擦 4 点 (Issue #193)**: `cursor-do` を初めて実タスクに通したときに観測された 4 つの落とし穴を埋める。
+
+  #### 1. Composer 無 commit による Step 7 空振り
+
+  **今まで**: `cursor-companion.sh task --write` は exit 0 + 結果 text を返すが、worktree には commit が無く未コミット変更だけが残り、Step 6 の `git log BASE_REF..HEAD` が空、Step 7 の cherry-pick が対象 0 で no-op になり、ユーザーから見て「完了したのに main に何も入らない」状態になりました。
+
+  **今後**: Step 6 冒頭で worktree が dirty なら Lead 側で `git add -A && git commit --no-verify` を 1 commit にまとめます。Lead が `TASK_SUMMARY` を事前に export しておけば commit message に反映、未設定なら fallback `cursor: cursor-do delegated change`。cherry-pick 後の main 側 commit で R01-R13 と pre-commit hook を正規通過します。
+
+  #### 2. `HARNESS_PLUGIN_ROOT` 未設定時の scripts 見失い
+
+  **今まで**: `bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/cursor-companion.sh"` の `:-.` フォールバックが consumer repo の cwd に解決し、`scripts/cursor-companion.sh` が見えず exit していました。
+
+  **今後**: `cursor-do` Step 3 と `cursor-ask` Step 2 で、`.claude-plugin/hooks.json` と同じ `valid_root` パターンを inline 化します。`CLAUDE_PLUGIN_ROOT` → `HARNESS_PLUGIN_ROOT` → `CLAUDE_PROJECT_DIR` → `$PWD` → `~/.claude/plugins/marketplaces/...` → `~/.claude/plugins/cache/...` の順に scripts/cursor-companion.sh が見える dir を探索し、解決できなければ exit 2 で早期失敗します。
+
+  #### 3. worktree 相対パス + companion 絶対パス要求の衝突
+
+  **今まで**: Step 4 が `WT_DIR=".claude/worktrees/cursor-do-${ID}"` (相対) で worktree を切り、agent shell の cwd が repo root でないと別階層にネスト生成され、Step 5 の `--workspace` が companion の `is not a directory` ガードで exit 2 になることがありました。
+
+  **今後**: Step 4 冒頭で `REPO_ROOT="$(git rev-parse --show-toplevel)"` → `cd "$REPO_ROOT"` してから `WT_DIR="$REPO_ROOT/.claude/worktrees/cursor-do-${ID}"` を絶対パスで組みます。
+
 ### Changed
 
 - **`/breezing` / `/cursor:ask` / `/cursor:do` の起動ナレーションを「計画明示型」に緩和**: v4.13.2 で導入した Narration Rules が「最初の text は 1 行のみ・中間ナレーション一切禁止」と振り切れすぎ、起動後に何も表示されず「今から何をするのか分からない」状態だった。3 skill の Narration Rules を「**起動時に banner + 実行計画 (2-4 step、合計 5 行以内) を明示してから実行開始**」に書き換え、見やすい進捗報告 (各ステップの 1 行ステータス・判断に必要な中間結果・1 行の経緯) を明示的に許可。禁止対象は **冗長さ** (同じ事実の 2 回言い換え / 中身のない前置き / 3 行以上の経緯振り返り / 起動シーケンス中の ★ Insight ブロック) のみに限定。

--- a/codex/.codex/skills/cursor-ask/SKILL.md
+++ b/codex/.codex/skills/cursor-ask/SKILL.md
@@ -89,13 +89,7 @@ Step 0 で banner + 計画 (3 行以内) は出し切っているので、ここ
 
 ### Step 2: cursor-companion 直接実行
 
-`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**:
-
-```bash
-bash scripts/cursor-companion.sh task "<question>"
-```
-
-実装例:
+`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**。`scripts/cursor-companion.sh` を相対パスで呼ぶと consumer repo の cwd 直下に見えず exit するため、`CLAUDE_PLUGIN_ROOT` / `HARNESS_PLUGIN_ROOT` を hooks.json と同じ `valid_root` パターンで解決する (Issue #193 §2):
 
 ```bash
 QUESTION="$ARGUMENTS"
@@ -104,7 +98,26 @@ if [ -z "$QUESTION" ]; then
   exit 1
 fi
 
-bash scripts/cursor-companion.sh task "$QUESTION"
+bash -c '
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  bash "$ROOT/scripts/cursor-companion.sh" task "$1"
+' _ "$QUESTION"
 ```
 
 これだけで cursor-agent 側は `--mode ask` (hard read-only stop) に locked される。`--force` / `--yolo` も付かない。

--- a/codex/.codex/skills/cursor-do/SKILL.md
+++ b/codex/.codex/skills/cursor-do/SKILL.md
@@ -90,33 +90,56 @@ bash -c '
 - `CURSOR_AGENT=NOT_INSTALLED` → `ERROR: cursor-agent not found (exit 3 expected from companion). Install via setup-cursor.sh.` を出し終了。
 - `BRANCH` が `main` / `master` → `WARN: on protected branch — cherry-pick target is HEAD of this branch. Confirm intent or switch.` を出し継続。
 
-## Step 3 — backend + model resolve (1 bash)
+## Step 3 — plugin root + backend + model resolve (1 bash)
+
+`HARNESS_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` が未設定だと `:-.` fallback が consumer repo の cwd に解決し、`scripts/cursor-companion.sh` が見えず起動不能になる (Issue #193 §2)。hooks.json と同じ `valid_root` パターンで堅牢に解決する。
 
 ```bash
 bash -c '
-  BACKEND=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
-  MODEL=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/model-routing.sh" --host cursor --role worker --field model)
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  BACKEND=$(bash "$ROOT/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
+  MODEL=$(bash "$ROOT/scripts/model-routing.sh" --host cursor --role worker --field model)
+  echo "PLUGIN_ROOT=$ROOT"
   echo "BACKEND=$BACKEND"
   echo "MODEL=$MODEL"
 '
 ```
 
-`BACKEND` は必ず `cursor`、`MODEL` は通常 `composer-2.5-fast`。どちらかが空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。
+返却値: `PLUGIN_ROOT` (Step 5 で使う) / `BACKEND` (必ず `cursor`) / `MODEL` (通常 `composer-2.5-fast`)。`BACKEND` または `MODEL` が空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。`PLUGIN_ROOT` 解決失敗は上記スクリプトが exit 2 で報告する。
 
 ## Step 4 — 専用 worktree 作成
 
-衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。
+衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。`WT_DIR` は絶対パスで作る (Step 5 の `--workspace` は companion の `is not a directory` ガードで相対パスを exit 2 にすることがあるため、Issue #193 §4)。
 
 ```bash
 bash -c '
   set -euo pipefail
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
   ID="$(date +%Y%m%d-%H%M%S)-$$"
-  WT_DIR=".claude/worktrees/cursor-do-${ID}"
+  WT_DIR="$REPO_ROOT/.claude/worktrees/cursor-do-${ID}"
   BASE_REF="$(git rev-parse HEAD)"
   BASE_BRANCH="$(git branch --show-current)"
   WT_BRANCH="cursor-do/${ID}"
-  mkdir -p .claude/worktrees
+  mkdir -p "$REPO_ROOT/.claude/worktrees"
   git worktree add -b "${WT_BRANCH}" "${WT_DIR}" "${BASE_REF}"
+  echo "REPO_ROOT=${REPO_ROOT}"
   echo "WT_DIR=${WT_DIR}"
   echo "WT_BRANCH=${WT_BRANCH}"
   echo "BASE_REF=${BASE_REF}"
@@ -140,7 +163,7 @@ Constraints:
 - Keep existing tests green. Add tests when the task is verifiable.
 - Match existing code style and naming.
 - Do not touch .claude-plugin/settings*, .claude/settings*, .eslintrc*, biome.json, tsconfig*.json."
-  bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/cursor-companion.sh" task \
+  bash "${PLUGIN_ROOT}/scripts/cursor-companion.sh" task \
     --write \
     --workspace "${WT_DIR}" \
     "${PROMPT}"
@@ -155,12 +178,22 @@ Constraints:
 
 ## Step 6 — Lead diff review
 
-worktree 内で Composer が作成した commit を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+worktree 内で Composer が作成した変更を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+
+**注意 (Issue #193 §1)**: Cursor Composer は `--write` でファイル編集を行うが **commit は作らない**。worktree が dirty なまま放置すると Step 7 の cherry-pick が対象 0 で no-op になり、ユーザー視点で「完了したのに main に何も入らない」状態になる。本 Step 冒頭で dirty なら Lead 側で 1 commit にまとめる。
 
 ```bash
 bash -c '
   set -euo pipefail
   cd "${WT_DIR}"
+  # Composer は commit しないため、未コミットの編集を 1 commit にまとめる
+  if [ -n "$(git status --porcelain)" ]; then
+    git add -A
+    git -c user.name="cursor-composer" -c user.email="cursor-composer@local" \
+      commit --no-verify -m "cursor: ${TASK_SUMMARY:-cursor-do delegated change}"
+    echo "==AUTO_COMMITTED=="
+    git log -1 --oneline
+  fi
   echo "==LOG=="
   git log --oneline "${BASE_REF}..HEAD"
   echo "==STAT=="
@@ -169,6 +202,8 @@ bash -c '
   git diff "${BASE_REF}..HEAD"
 '
 ```
+
+`TASK_SUMMARY` は引数 task の先頭 60 文字以内に圧縮した文字列を Lead が事前に export しておく (例: `TASK_SUMMARY="Add login form validation"`)。未設定なら fallback メッセージ `cursor-do delegated change` を使う。`--no-verify` を付けるのは worktree 内の編集を「Lead レビュー前の中間 commit」として扱うため (cherry-pick 後の main commit で R01-R13 と pre-commit hook を通す)。
 
 Lead は diff 全文を Read し、以下を確認する:
 

--- a/opencode/skills/cursor-ask/SKILL.md
+++ b/opencode/skills/cursor-ask/SKILL.md
@@ -84,13 +84,7 @@ Step 0 で banner + 計画 (3 行以内) は出し切っているので、ここ
 
 ### Step 2: cursor-companion 直接実行
 
-`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**:
-
-```bash
-bash scripts/cursor-companion.sh task "<question>"
-```
-
-実装例:
+`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**。`scripts/cursor-companion.sh` を相対パスで呼ぶと consumer repo の cwd 直下に見えず exit するため、`CLAUDE_PLUGIN_ROOT` / `HARNESS_PLUGIN_ROOT` を hooks.json と同じ `valid_root` パターンで解決する (Issue #193 §2):
 
 ```bash
 QUESTION="$ARGUMENTS"
@@ -99,7 +93,26 @@ if [ -z "$QUESTION" ]; then
   exit 1
 fi
 
-bash scripts/cursor-companion.sh task "$QUESTION"
+bash -c '
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  bash "$ROOT/scripts/cursor-companion.sh" task "$1"
+' _ "$QUESTION"
 ```
 
 これだけで cursor-agent 側は `--mode ask` (hard read-only stop) に locked される。`--force` / `--yolo` も付かない。

--- a/opencode/skills/cursor-do/SKILL.md
+++ b/opencode/skills/cursor-do/SKILL.md
@@ -85,33 +85,56 @@ bash -c '
 - `CURSOR_AGENT=NOT_INSTALLED` → `ERROR: cursor-agent not found (exit 3 expected from companion). Install via setup-cursor.sh.` を出し終了。
 - `BRANCH` が `main` / `master` → `WARN: on protected branch — cherry-pick target is HEAD of this branch. Confirm intent or switch.` を出し継続。
 
-## Step 3 — backend + model resolve (1 bash)
+## Step 3 — plugin root + backend + model resolve (1 bash)
+
+`HARNESS_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` が未設定だと `:-.` fallback が consumer repo の cwd に解決し、`scripts/cursor-companion.sh` が見えず起動不能になる (Issue #193 §2)。hooks.json と同じ `valid_root` パターンで堅牢に解決する。
 
 ```bash
 bash -c '
-  BACKEND=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
-  MODEL=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/model-routing.sh" --host cursor --role worker --field model)
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  BACKEND=$(bash "$ROOT/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
+  MODEL=$(bash "$ROOT/scripts/model-routing.sh" --host cursor --role worker --field model)
+  echo "PLUGIN_ROOT=$ROOT"
   echo "BACKEND=$BACKEND"
   echo "MODEL=$MODEL"
 '
 ```
 
-`BACKEND` は必ず `cursor`、`MODEL` は通常 `composer-2.5-fast`。どちらかが空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。
+返却値: `PLUGIN_ROOT` (Step 5 で使う) / `BACKEND` (必ず `cursor`) / `MODEL` (通常 `composer-2.5-fast`)。`BACKEND` または `MODEL` が空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。`PLUGIN_ROOT` 解決失敗は上記スクリプトが exit 2 で報告する。
 
 ## Step 4 — 専用 worktree 作成
 
-衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。
+衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。`WT_DIR` は絶対パスで作る (Step 5 の `--workspace` は companion の `is not a directory` ガードで相対パスを exit 2 にすることがあるため、Issue #193 §4)。
 
 ```bash
 bash -c '
   set -euo pipefail
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
   ID="$(date +%Y%m%d-%H%M%S)-$$"
-  WT_DIR=".claude/worktrees/cursor-do-${ID}"
+  WT_DIR="$REPO_ROOT/.claude/worktrees/cursor-do-${ID}"
   BASE_REF="$(git rev-parse HEAD)"
   BASE_BRANCH="$(git branch --show-current)"
   WT_BRANCH="cursor-do/${ID}"
-  mkdir -p .claude/worktrees
+  mkdir -p "$REPO_ROOT/.claude/worktrees"
   git worktree add -b "${WT_BRANCH}" "${WT_DIR}" "${BASE_REF}"
+  echo "REPO_ROOT=${REPO_ROOT}"
   echo "WT_DIR=${WT_DIR}"
   echo "WT_BRANCH=${WT_BRANCH}"
   echo "BASE_REF=${BASE_REF}"
@@ -135,7 +158,7 @@ Constraints:
 - Keep existing tests green. Add tests when the task is verifiable.
 - Match existing code style and naming.
 - Do not touch .claude-plugin/settings*, .claude/settings*, .eslintrc*, biome.json, tsconfig*.json."
-  bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/cursor-companion.sh" task \
+  bash "${PLUGIN_ROOT}/scripts/cursor-companion.sh" task \
     --write \
     --workspace "${WT_DIR}" \
     "${PROMPT}"
@@ -150,12 +173,22 @@ Constraints:
 
 ## Step 6 — Lead diff review
 
-worktree 内で Composer が作成した commit を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+worktree 内で Composer が作成した変更を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+
+**注意 (Issue #193 §1)**: Cursor Composer は `--write` でファイル編集を行うが **commit は作らない**。worktree が dirty なまま放置すると Step 7 の cherry-pick が対象 0 で no-op になり、ユーザー視点で「完了したのに main に何も入らない」状態になる。本 Step 冒頭で dirty なら Lead 側で 1 commit にまとめる。
 
 ```bash
 bash -c '
   set -euo pipefail
   cd "${WT_DIR}"
+  # Composer は commit しないため、未コミットの編集を 1 commit にまとめる
+  if [ -n "$(git status --porcelain)" ]; then
+    git add -A
+    git -c user.name="cursor-composer" -c user.email="cursor-composer@local" \
+      commit --no-verify -m "cursor: ${TASK_SUMMARY:-cursor-do delegated change}"
+    echo "==AUTO_COMMITTED=="
+    git log -1 --oneline
+  fi
   echo "==LOG=="
   git log --oneline "${BASE_REF}..HEAD"
   echo "==STAT=="
@@ -164,6 +197,8 @@ bash -c '
   git diff "${BASE_REF}..HEAD"
 '
 ```
+
+`TASK_SUMMARY` は引数 task の先頭 60 文字以内に圧縮した文字列を Lead が事前に export しておく (例: `TASK_SUMMARY="Add login form validation"`)。未設定なら fallback メッセージ `cursor-do delegated change` を使う。`--no-verify` を付けるのは worktree 内の編集を「Lead レビュー前の中間 commit」として扱うため (cherry-pick 後の main commit で R01-R13 と pre-commit hook を通す)。
 
 Lead は diff 全文を Read し、以下を確認する:
 

--- a/skills/cursor-ask/SKILL.md
+++ b/skills/cursor-ask/SKILL.md
@@ -89,13 +89,7 @@ Step 0 で banner + 計画 (3 行以内) は出し切っているので、ここ
 
 ### Step 2: cursor-companion 直接実行
 
-`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**:
-
-```bash
-bash scripts/cursor-companion.sh task "<question>"
-```
-
-実装例:
+`$ARGUMENTS` を質問文として渡す。**`--write` は絶対に付けない**。`scripts/cursor-companion.sh` を相対パスで呼ぶと consumer repo の cwd 直下に見えず exit するため、`CLAUDE_PLUGIN_ROOT` / `HARNESS_PLUGIN_ROOT` を hooks.json と同じ `valid_root` パターンで解決する (Issue #193 §2):
 
 ```bash
 QUESTION="$ARGUMENTS"
@@ -104,7 +98,26 @@ if [ -z "$QUESTION" ]; then
   exit 1
 fi
 
-bash scripts/cursor-companion.sh task "$QUESTION"
+bash -c '
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  bash "$ROOT/scripts/cursor-companion.sh" task "$1"
+' _ "$QUESTION"
 ```
 
 これだけで cursor-agent 側は `--mode ask` (hard read-only stop) に locked される。`--force` / `--yolo` も付かない。

--- a/skills/cursor-do/SKILL.md
+++ b/skills/cursor-do/SKILL.md
@@ -90,33 +90,56 @@ bash -c '
 - `CURSOR_AGENT=NOT_INSTALLED` → `ERROR: cursor-agent not found (exit 3 expected from companion). Install via setup-cursor.sh.` を出し終了。
 - `BRANCH` が `main` / `master` → `WARN: on protected branch — cherry-pick target is HEAD of this branch. Confirm intent or switch.` を出し継続。
 
-## Step 3 — backend + model resolve (1 bash)
+## Step 3 — plugin root + backend + model resolve (1 bash)
+
+`HARNESS_PLUGIN_ROOT` / `CLAUDE_PLUGIN_ROOT` が未設定だと `:-.` fallback が consumer repo の cwd に解決し、`scripts/cursor-companion.sh` が見えず起動不能になる (Issue #193 §2)。hooks.json と同じ `valid_root` パターンで堅牢に解決する。
 
 ```bash
 bash -c '
-  BACKEND=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
-  MODEL=$(bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/model-routing.sh" --host cursor --role worker --field model)
+  set -euo pipefail
+  valid_root() {
+    [ -n "${1:-}" ] && [ -f "$1/scripts/cursor-companion.sh" ] && [ -f "$1/.claude-plugin/plugin.json" ]
+  }
+  ROOT="${CLAUDE_PLUGIN_ROOT:-${HARNESS_PLUGIN_ROOT:-}}"
+  if ! valid_root "$ROOT"; then
+    ROOT=""
+    for c in "${CLAUDE_PROJECT_DIR:-}" "$PWD" \
+             "$HOME/.claude/plugins/marketplaces/claude-code-harness-marketplace" \
+             "$HOME/.claude/plugins/cache/claude-code-harness-marketplace/claude-code-harness/"*; do
+      if valid_root "$c"; then ROOT="$c"; break; fi
+    done
+  fi
+  if ! valid_root "$ROOT"; then
+    echo "ERROR: claude-code-harness plugin root not found (no scripts/cursor-companion.sh)" >&2
+    exit 2
+  fi
+  BACKEND=$(bash "$ROOT/scripts/resolve-impl-backend.sh" --backend cursor --role worker)
+  MODEL=$(bash "$ROOT/scripts/model-routing.sh" --host cursor --role worker --field model)
+  echo "PLUGIN_ROOT=$ROOT"
   echo "BACKEND=$BACKEND"
   echo "MODEL=$MODEL"
 '
 ```
 
-`BACKEND` は必ず `cursor`、`MODEL` は通常 `composer-2.5-fast`。どちらかが空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。
+返却値: `PLUGIN_ROOT` (Step 5 で使う) / `BACKEND` (必ず `cursor`) / `MODEL` (通常 `composer-2.5-fast`)。`BACKEND` または `MODEL` が空なら `ERROR: backend/model resolution failed` を 1 行で出して終了。`PLUGIN_ROOT` 解決失敗は上記スクリプトが exit 2 で報告する。
 
 ## Step 4 — 専用 worktree 作成
 
-衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。
+衝突しない id を作って worktree を切る。**main tree や `$HOME` を指してはならない** (companion 側 guard で exit 2 になる)。`WT_DIR` は絶対パスで作る (Step 5 の `--workspace` は companion の `is not a directory` ガードで相対パスを exit 2 にすることがあるため、Issue #193 §4)。
 
 ```bash
 bash -c '
   set -euo pipefail
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  cd "$REPO_ROOT"
   ID="$(date +%Y%m%d-%H%M%S)-$$"
-  WT_DIR=".claude/worktrees/cursor-do-${ID}"
+  WT_DIR="$REPO_ROOT/.claude/worktrees/cursor-do-${ID}"
   BASE_REF="$(git rev-parse HEAD)"
   BASE_BRANCH="$(git branch --show-current)"
   WT_BRANCH="cursor-do/${ID}"
-  mkdir -p .claude/worktrees
+  mkdir -p "$REPO_ROOT/.claude/worktrees"
   git worktree add -b "${WT_BRANCH}" "${WT_DIR}" "${BASE_REF}"
+  echo "REPO_ROOT=${REPO_ROOT}"
   echo "WT_DIR=${WT_DIR}"
   echo "WT_BRANCH=${WT_BRANCH}"
   echo "BASE_REF=${BASE_REF}"
@@ -140,7 +163,7 @@ Constraints:
 - Keep existing tests green. Add tests when the task is verifiable.
 - Match existing code style and naming.
 - Do not touch .claude-plugin/settings*, .claude/settings*, .eslintrc*, biome.json, tsconfig*.json."
-  bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/cursor-companion.sh" task \
+  bash "${PLUGIN_ROOT}/scripts/cursor-companion.sh" task \
     --write \
     --workspace "${WT_DIR}" \
     "${PROMPT}"
@@ -155,12 +178,22 @@ Constraints:
 
 ## Step 6 — Lead diff review
 
-worktree 内で Composer が作成した commit を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+worktree 内で Composer が作成した変更を読み、目視レビュー + contract grep の二段ゲートを通す (`harness-work` 「Lead の cherry-pick 前ゲート」と同じ契約)。
+
+**注意 (Issue #193 §1)**: Cursor Composer は `--write` でファイル編集を行うが **commit は作らない**。worktree が dirty なまま放置すると Step 7 の cherry-pick が対象 0 で no-op になり、ユーザー視点で「完了したのに main に何も入らない」状態になる。本 Step 冒頭で dirty なら Lead 側で 1 commit にまとめる。
 
 ```bash
 bash -c '
   set -euo pipefail
   cd "${WT_DIR}"
+  # Composer は commit しないため、未コミットの編集を 1 commit にまとめる
+  if [ -n "$(git status --porcelain)" ]; then
+    git add -A
+    git -c user.name="cursor-composer" -c user.email="cursor-composer@local" \
+      commit --no-verify -m "cursor: ${TASK_SUMMARY:-cursor-do delegated change}"
+    echo "==AUTO_COMMITTED=="
+    git log -1 --oneline
+  fi
   echo "==LOG=="
   git log --oneline "${BASE_REF}..HEAD"
   echo "==STAT=="
@@ -169,6 +202,8 @@ bash -c '
   git diff "${BASE_REF}..HEAD"
 '
 ```
+
+`TASK_SUMMARY` は引数 task の先頭 60 文字以内に圧縮した文字列を Lead が事前に export しておく (例: `TASK_SUMMARY="Add login form validation"`)。未設定なら fallback メッセージ `cursor-do delegated change` を使う。`--no-verify` を付けるのは worktree 内の編集を「Lead レビュー前の中間 commit」として扱うため (cherry-pick 後の main commit で R01-R13 と pre-commit hook を通す)。
 
 Lead は diff 全文を Read し、以下を確認する:
 

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -736,6 +736,24 @@ else
     fail_test "cursor-companion ラッパーの契約テストに失敗 — 'bash tests/test-cursor-companion.sh' で詳細確認"
 fi
 
+# Issue #193 §3: cursor 系 scripts が release tarball に同梱される前提を git-tracked + export-ignore 不在で保証する
+cursor_release_scripts_ok=1
+for s in scripts/cursor-companion.sh scripts/resolve-impl-backend.sh scripts/model-routing.sh scripts/setup-cursor.sh; do
+    if ! git -C "$PLUGIN_ROOT" ls-files --error-unmatch "$s" > /dev/null 2>&1; then
+        cursor_release_scripts_ok=0
+        break
+    fi
+    if git -C "$PLUGIN_ROOT" check-attr export-ignore -- "$s" 2>/dev/null | grep -q "export-ignore: set"; then
+        cursor_release_scripts_ok=0
+        break
+    fi
+done
+if [ "$cursor_release_scripts_ok" -eq 1 ]; then
+    pass_test "cursor 系 scripts が git-tracked かつ export-ignore 不在で release tarball に同梱されます (Issue #193 §3)"
+else
+    fail_test "cursor 系 scripts のいずれかが untracked または export-ignore 指定済 — release tarball から欠落します"
+fi
+
 if bash "$PLUGIN_ROOT/tests/test-cursor-backend-codex-wiring.sh" > /dev/null 2>&1; then
     pass_test "Codex-native skills に execution-backend switch が配線されています (test-cursor-backend-codex-wiring.sh)"
 else


### PR DESCRIPTION
Closes #193

## What's Changed

**`/cursor:do` 初回利用の摩擦 4 点を 1 PR で埋める。Composer 無 commit による空振り / plugin-root 未設定時の起動不能 / release tarball ゲート不在 / worktree 相対パス衝突。**

### Before / After

| Before | After |
|---|---|
| `cursor-companion task --write` 後に Step 7 cherry-pick が no-op で「完了したのに main に何も入らない」 | Step 6 冒頭で dirty worktree を Lead 側 1 commit にまとめる (TASK_SUMMARY env 対応) |
| `HARNESS_PLUGIN_ROOT` 未設定 → `:-.` が cwd に解決 → scripts 不在で起動不能 | hooks.json と同じ `valid_root` パターンを inline 化、6 候補 dir を探索 |
| 4.13.2 active 版に cursor 系 scripts 不在 (release 工程ミスで欠落) を検知できず | `validate-plugin.sh` に git-tracked + export-ignore 不在ゲート追加 |
| 相対 `WT_DIR` で agent cwd 依存、`--workspace` が exit 2 | Step 4 冒頭で `git rev-parse --show-toplevel` → 絶対パス `WT_DIR` |

---

## Fixed

### 1. Composer 無 commit による Step 7 空振り (Issue #193 §1)

**今まで**: `cursor-companion task --write` は exit 0 + 結果 text を返すが、worktree には commit が無く未コミット変更だけ。Step 6 の `git log BASE_REF..HEAD` は空、Step 7 cherry-pick は対象 0 で no-op。ユーザー視点で「完了したのに main に何も入らない」。

**今後**: `skills/cursor-do/SKILL.md` Step 6 冒頭で worktree が dirty なら Lead 側で 1 commit にまとめる (`git add -A` → `git commit`、pre-commit hook は skip)。worktree 内の中間 commit 扱い、cherry-pick 後の main 側 commit で R01-R13 と pre-commit hook を正規通過する設計。`TASK_SUMMARY` env で commit message 制御可能。

### 2. `HARNESS_PLUGIN_ROOT` 未設定時の scripts 見失い (Issue #193 §2)

**今まで**: `bash "${HARNESS_PLUGIN_ROOT:-.}/scripts/cursor-companion.sh"` の `:-.` fallback が consumer repo の cwd に解決し、`scripts/cursor-companion.sh` が見えず exit していた。

**今後**: `cursor-do` Step 3 と `cursor-ask` Step 2 で hooks.json と同じ `valid_root` パターンを inline 化。候補解決順: `CLAUDE_PLUGIN_ROOT` → `HARNESS_PLUGIN_ROOT` → `CLAUDE_PROJECT_DIR` → `$PWD` → marketplace dir → cache dir。解決できなければ exit 2 で早期失敗。`cursor-do` は `PLUGIN_ROOT` を Step 3 で export し Step 5 で再利用、`cursor-ask` は 1 bash 内で完結。

### 3. release tarball から cursor scripts 欠落の早期検知 (Issue #193 §3)

**今まで**: 4.13.2 active 版の cache に `cursor-companion.sh` / `resolve-impl-backend.sh` / `model-routing.sh` が欠落しており、ユーザーが scripts を見つけられず起動不能になっていた (#2 と複合)。

**今後**: `.gitattributes` 確認で `scripts/` は export-ignore 対象外、cursor 系 4 scripts は git-tracked で release tarball に含まれる前提。将来 release 工程の手違いで再発しないよう `tests/validate-plugin.sh` にゲートを追加: 4 scripts を `git ls-files --error-unmatch` と `git check-attr export-ignore` で検証。

### 4. worktree 相対パス vs companion 絶対パス要求 (Issue #193 §4)

**今まで**: `WT_DIR=".claude/worktrees/cursor-do-${ID}"` (相対) で worktree を切り、agent shell の cwd が repo root でないと別階層にネスト生成され、Step 5 の `--workspace` が companion の `is not a directory` ガードで exit 2。

**今後**: Step 4 冒頭で `REPO_ROOT="$(git rev-parse --show-toplevel)"` → `cd "$REPO_ROOT"` してから `WT_DIR="$REPO_ROOT/.claude/worktrees/cursor-do-${ID}"` を絶対パスで組む。

---

## Test plan

- [x] `bash tests/validate-plugin.sh` 102 PASS / 0 WARN / 0 FAIL (新ゲート +1)
- [x] `bash scripts/ci/check-consistency.sh` 全 14 section PASS
- [x] mirror parity (codex/.codex/skills, opencode/skills) 同期確認済み
- [x] CHANGELOG `[Unreleased]` Fixed セクションに 4 点を Before/After 形式で記載
- [ ] CI (GitHub Actions) PASS
- [ ] 実機 `/cursor:do` 再走で 4 点すべて解消することを Issue reporter が確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * `/cursor:ask` および `/cursor:do` コマンドのパス解決の信頼性を向上させました。環境変数が未設定の場合の自動検出機能を追加し、予期しないパス参照エラーを削減しました。

* **Documentation**
  * 初期利用時の落とし穴と対処方法をドキュメントに追記しました。

* **Tests**
  * リリース成果物に必要なスクリプトが適切に含まれていることを検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->