### PR TITLE
refactor(harness-review): restore dispatcher headroom under the 350-line gate

### DIFF
--- a/codex/.codex/skills/harness-review/SKILL.md
+++ b/codex/.codex/skills/harness-review/SKILL.md
@@ -110,42 +110,10 @@ REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={
 `REVIEW_TARGET_ASK` 契約:
 bare 呼び出しで review target が不明または複数候補の場合、Step 1 に進む前に `AskUserQuestion` を 1 回だけ使い、候補を 2-3 個に絞って確認する。
 
-候補は次の順で作る。
-
-1. working tree: staged / unstaged / untracked を含む未コミット変更のみ
-2. branch range: upstream または main/master から HEAD までの commits
-3. recent commits: clean tree で branch range が取れない場合の直近 1 commit / 直近 5 commits
-
-複数候補が同時に成立する場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
-- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
-- commit のみ: branch base..HEAD の committed work だけを見る
-
-clean tree かつ branch 差分がない場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 直近 1 commit (Recommended): HEAD~1..HEAD
-- 直近 5 commits: HEAD~5..HEAD
-- 別の範囲: ユーザー指定 ref を待つ
-
-ユーザー回答後:
-
-```text
-REVIEW_TARGET_CONFIRMED: {choice}
-REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
-```
+- 候補は 1. working tree（未コミット変更のみ）、2. branch range（upstream または main/master から HEAD）、3. recent commits（clean tree 時の直近 1 commit / 直近 5 commits）の順で作る
+- 複数候補が同時に成立する場合は `REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`、clean tree かつ branch 差分がない場合は `REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits` を 1 行出力してから AskUserQuestion を出す
+- ユーザー回答後は `REVIEW_TARGET_CONFIRMED: {choice}` に続けて `REVIEW_AUTOSTART` 行を出力する
+- AskUserQuestion の選択肢 literal・推奨 (Recommended) の付け方・各候補の比較範囲は `references/code-review.md` の Target Selection 節に従う
 
 禁止:
 

--- a/codex/.codex/skills/harness-review/references/code-review.md
+++ b/codex/.codex/skills/harness-review/references/code-review.md
@@ -4,6 +4,30 @@
 
 差分を集め、実装・仕様・Plans・デグレ・テストを見て、止めるべき問題だけを止める。
 
+## Target Selection
+
+`SKILL.md` の Review Target Detection（`REVIEW_TARGET_ASK` 契約）から参照される。
+bare 呼び出しで target が曖昧な場合の AskUserQuestion 選択肢 literal と推奨順をここで固定する。
+
+複数候補が同時に成立する場合（`REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`）:
+
+- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
+- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
+- commit のみ: branch base..HEAD の committed work だけを見る
+
+clean tree かつ branch 差分がない場合（`REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits`）:
+
+- 直近 1 commit (Recommended): HEAD~1..HEAD
+- 直近 5 commits: HEAD~5..HEAD
+- 別の範囲: ユーザー指定 ref を待つ
+
+ユーザー回答後:
+
+```text
+REVIEW_TARGET_CONFIRMED: {choice}
+REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
+```
+
 ## Step 1: collect diff
 
 確認するもの:

--- a/opencode/skills/harness-review/SKILL.md
+++ b/opencode/skills/harness-review/SKILL.md
@@ -95,42 +95,10 @@ REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={
 `REVIEW_TARGET_ASK` 契約:
 bare 呼び出しで review target が不明または複数候補の場合、Step 1 に進む前に `AskUserQuestion` を 1 回だけ使い、候補を 2-3 個に絞って確認する。
 
-候補は次の順で作る。
-
-1. working tree: staged / unstaged / untracked を含む未コミット変更のみ
-2. branch range: upstream または main/master から HEAD までの commits
-3. recent commits: clean tree で branch range が取れない場合の直近 1 commit / 直近 5 commits
-
-複数候補が同時に成立する場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
-- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
-- commit のみ: branch base..HEAD の committed work だけを見る
-
-clean tree かつ branch 差分がない場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 直近 1 commit (Recommended): HEAD~1..HEAD
-- 直近 5 commits: HEAD~5..HEAD
-- 別の範囲: ユーザー指定 ref を待つ
-
-ユーザー回答後:
-
-```text
-REVIEW_TARGET_CONFIRMED: {choice}
-REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
-```
+- 候補は 1. working tree（未コミット変更のみ）、2. branch range（upstream または main/master から HEAD）、3. recent commits（clean tree 時の直近 1 commit / 直近 5 commits）の順で作る
+- 複数候補が同時に成立する場合は `REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`、clean tree かつ branch 差分がない場合は `REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits` を 1 行出力してから AskUserQuestion を出す
+- ユーザー回答後は `REVIEW_TARGET_CONFIRMED: {choice}` に続けて `REVIEW_AUTOSTART` 行を出力する
+- AskUserQuestion の選択肢 literal・推奨 (Recommended) の付け方・各候補の比較範囲は `references/code-review.md` の Target Selection 節に従う
 
 禁止:
 

--- a/opencode/skills/harness-review/references/code-review.md
+++ b/opencode/skills/harness-review/references/code-review.md
@@ -4,6 +4,30 @@
 
 差分を集め、実装・仕様・Plans・デグレ・テストを見て、止めるべき問題だけを止める。
 
+## Target Selection
+
+`SKILL.md` の Review Target Detection（`REVIEW_TARGET_ASK` 契約）から参照される。
+bare 呼び出しで target が曖昧な場合の AskUserQuestion 選択肢 literal と推奨順をここで固定する。
+
+複数候補が同時に成立する場合（`REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`）:
+
+- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
+- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
+- commit のみ: branch base..HEAD の committed work だけを見る
+
+clean tree かつ branch 差分がない場合（`REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits`）:
+
+- 直近 1 commit (Recommended): HEAD~1..HEAD
+- 直近 5 commits: HEAD~5..HEAD
+- 別の範囲: ユーザー指定 ref を待つ
+
+ユーザー回答後:
+
+```text
+REVIEW_TARGET_CONFIRMED: {choice}
+REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
+```
+
 ## Step 1: collect diff
 
 確認するもの:

--- a/skills/harness-review/SKILL.md
+++ b/skills/harness-review/SKILL.md
@@ -110,42 +110,10 @@ REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={
 `REVIEW_TARGET_ASK` 契約:
 bare 呼び出しで review target が不明または複数候補の場合、Step 1 に進む前に `AskUserQuestion` を 1 回だけ使い、候補を 2-3 個に絞って確認する。
 
-候補は次の順で作る。
-
-1. working tree: staged / unstaged / untracked を含む未コミット変更のみ
-2. branch range: upstream または main/master から HEAD までの commits
-3. recent commits: clean tree で branch range が取れない場合の直近 1 commit / 直近 5 commits
-
-複数候補が同時に成立する場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
-- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
-- commit のみ: branch base..HEAD の committed work だけを見る
-
-clean tree かつ branch 差分がない場合:
-
-```text
-REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits
-```
-
-AskUserQuestion の候補:
-
-- 直近 1 commit (Recommended): HEAD~1..HEAD
-- 直近 5 commits: HEAD~5..HEAD
-- 別の範囲: ユーザー指定 ref を待つ
-
-ユーザー回答後:
-
-```text
-REVIEW_TARGET_CONFIRMED: {choice}
-REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
-```
+- 候補は 1. working tree（未コミット変更のみ）、2. branch range（upstream または main/master から HEAD）、3. recent commits（clean tree 時の直近 1 commit / 直近 5 commits）の順で作る
+- 複数候補が同時に成立する場合は `REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`、clean tree かつ branch 差分がない場合は `REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits` を 1 行出力してから AskUserQuestion を出す
+- ユーザー回答後は `REVIEW_TARGET_CONFIRMED: {choice}` に続けて `REVIEW_AUTOSTART` 行を出力する
+- AskUserQuestion の選択肢 literal・推奨 (Recommended) の付け方・各候補の比較範囲は `references/code-review.md` の Target Selection 節に従う
 
 禁止:
 

--- a/skills/harness-review/references/code-review.md
+++ b/skills/harness-review/references/code-review.md
@@ -4,6 +4,30 @@
 
 差分を集め、実装・仕様・Plans・デグレ・テストを見て、止めるべき問題だけを止める。
 
+## Target Selection
+
+`SKILL.md` の Review Target Detection（`REVIEW_TARGET_ASK` 契約）から参照される。
+bare 呼び出しで target が曖昧な場合の AskUserQuestion 選択肢 literal と推奨順をここで固定する。
+
+複数候補が同時に成立する場合（`REVIEW_TARGET_AMBIGUOUS: working_tree_and_branch_commits`）:
+
+- 未コミット変更のみ (Recommended): staged / unstaged / untracked を HEAD と比較して見る
+- 全部見る: branch base..HEAD と未コミット変更をまとめて見る
+- commit のみ: branch base..HEAD の committed work だけを見る
+
+clean tree かつ branch 差分がない場合（`REVIEW_TARGET_AMBIGUOUS: clean_tree_no_branch_commits`）:
+
+- 直近 1 commit (Recommended): HEAD~1..HEAD
+- 直近 5 commits: HEAD~5..HEAD
+- 別の範囲: ユーザー指定 ref を待つ
+
+ユーザー回答後:
+
+```text
+REVIEW_TARGET_CONFIRMED: {choice}
+REVIEW_AUTOSTART: target={resolved_target}, base_ref={resolved_base_ref}, type={mode}
+```
+
 ## Step 1: collect diff
 
 確認するもの:


### PR DESCRIPTION
## Summary

`skills/harness-review/SKILL.md` sat at exactly **350/350 lines** against the governance dispatcher size gate (`tests/test-harness-review-governance.sh` fails at `-gt 350`), so any 1-line addition — like the next required-term update — would fail CI. Found during the PR #212 review.

## Changes

- Compressed the verbose AskUserQuestion option literals in the Review Target Detection section into 4 summary bullets, keeping the `REVIEW_TARGET_ASK` / `REVIEW_TARGET_AMBIGUOUS` / `REVIEW_TARGET_CONFIRMED` contract lines and all governance grep terms in the dispatcher.
- Moved the option literals (recommended order, comparison ranges) into a new **Target Selection** section in `references/code-review.md`, which the same bare/`code` mode already loads.
- Mirrors synced via `scripts/sync-skill-mirrors.sh` (codex byte-identical, opencode body).

**Result: 350 → 318 lines (32 lines of headroom). No behavior change.**

## Verification

- `bash tests/test-harness-review-governance.sh` ok
- All 8 other tests grepping harness-review SKILL.md: PASS
- `./tests/validate-plugin.sh` (104 PASS), `bash scripts/ci/check-consistency.sh`, `bash scripts/sync-skill-mirrors.sh --check` all green

## Review

Multi-agent adversarial review (contract / runtime-regression lenses): **APPROVE**, no confirmed findings — content equivalence of the moved literals, AUTO-START CONTRACT position, required-term retention, and mirror sync all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **ドキュメント**
  * コードレビュー対象の選択ルールを整理。複数候補や曖昧な場合の判定基準、ユーザー確認フローの出力形式を明確化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->