### PR TITLE
fix(tests): materialize generated .cursor/hooks.json in release preflight

### DIFF
--- a/tests/test-cursor-adapter-candidate.sh
+++ b/tests/test-cursor-adapter-candidate.sh
@@ -28,6 +28,12 @@ assert_file "$MANIFEST"
 assert_file "$AGENTS"
 assert_file "$EVIDENCE"
 assert_file "$INTEGRATION"
+# .cursor/hooks.json is a generated build artifact (gitignored, FACT-1);
+# clean checkouts (CI release preflight) must materialize it via the
+# generator before asserting existence (FACT-4: materialize, don't infer).
+if [ ! -f "${ROOT_DIR}/.cursor/hooks.json" ]; then
+  "${ROOT_DIR}/bin/harness" gen >/dev/null
+fi
 assert_file "${ROOT_DIR}/.cursor/hooks.json"
 assert_file "${ROOT_DIR}/.cursor/mcp.json"
 assert_file "${ROOT_DIR}/.cursor/agents/worker.md"


### PR DESCRIPTION
Unblocks the v5.0.0 auto-release workflow: release preflight failed on clean checkouts because .cursor/hooks.json is now a generated gitignored artifact but the cursor adapter smoke asserted its existence. The test now materializes it via bin/harness gen when missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJCgLmiCCCdfE7ptPftkzx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * 生成済みの設定ファイルが存在しない環境でも、確認手順が失敗しないようになりました。
  * クリーンなチェックアウトやCIの事前確認でも、必要なファイルが自動的に用意されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->