### PR TITLE
docs: add optional Parallel Search MCP setup example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Added
+
+- Claude Code setup guide に、account や API key を必要としない optional な
+  Parallel Search MCP の remote HTTP 設定例を追加。
+
 ## [5.6.0] - 2026-08-01
 
 ### テーマ: 実行時フロアの回避経路封鎖と、検査基盤の信頼性回復 (Phase 127-129)

--- a/docs/claude-code-setup-mcp-telemetry-provider.md
+++ b/docs/claude-code-setup-mcp-telemetry-provider.md
@@ -77,6 +77,28 @@ MCP tool search は context 節約のために tool schema を遅延ロードす
 }
 ```
 
+## Parallel Search MCP (optional)
+
+現在の Web 検索と URL 本文の取得が必要な場合は、Parallel Search MCP を
+remote HTTP server として opt-in できる。既存の `mcpServers` を置き換えず、
+次の entry を merge する。
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+default endpoint は account、API key、OAuth を必要としない。
+`web_search` は現在の Web 検索、`web_fetch` は指定 URL から clean Markdown を
+取得する。毎 turn 必須の server ではないため、通常は `alwaysLoad` を付けず
+deferred のまま使う。Harness の default server や provider は変更しない。
+
 ## Plugin cleanup
 
 `claude plugin prune` は、plugin dependency として自動インストールされたが、今は不要になった plugin を消す cleanup。


### PR DESCRIPTION
The Claude Code setup guide already explains how to keep occasional MCP servers deferred. This adds a concrete opt-in example for users who want current web search and URL-to-Markdown fetching without changing Harness defaults.

## What changed

- Added a remote HTTP configuration example for Parallel Search MCP.
- Documented the default endpoint's no-account setup and its `web_search` and `web_fetch` tools.
- Added the required note under the Unreleased changelog section.

## Validation

- `git diff --check`
- Parsed the documented JSON configuration.
- `bash tests/test-public-claims-contract.sh`
- `bash tests/test-writing-norms-gate.sh`
- `bash scripts/ci/check-consistency.sh`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.