### PR TITLE
chore(deps): CodeQL action を 4.37.6 へ揃える (#307, #308, #309)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         uses: ./.github/actions/setup-go-harness
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: go
           build-mode: manual
@@ -50,6 +50,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -50,6 +50,6 @@ jobs:
           retention-days: 7
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
dependabot の CodeQL action 3 件 (#307, #308, #309) を 1 本にまとめます。

## なぜ統合が必要か

CodeQL の `init` / `analyze` / `upload-sarif` は**版が一致している必要があります**。dependabot が 3 つの別 PR に割ったため、1 つだけ merge すると必ず壊れます。

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.6'
```

これは rebase 後の #307 / #309 で実際に出ていたエラーです。**PR の中身ではなく、分割されたこと自体が原因**です。

結果として個別 PR は構造上 CI を通せず、branch protection が merge を拒否していました。`--admin` による強制 merge も可能でしたが、それは保護を迂回して赤いまま入れる行為なので採りません。3 件を統合して **CI を正当に緑にしてから** merge します。

## 変更

3 行の SHA 差し替えのみ。ロジック・step 構成・権限は一切変えていません。

| ファイル | action |
|---|---|
| `.github/workflows/codeql.yml` | `init`, `analyze` |
| `.github/workflows/scorecard.yml` | `upload-sarif` |

```
e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 (v4.37.3)
  → 5595ccaf912efad79be6eef63a5619ff05969be3 (v4.37.6)
```

差し替え先の SHA は dependabot が 3 件とも提示していたものと同一です。

## 統治上の位置づけ

`.github/workflows/` は `CLAUDE.md` の Permission Boundaries と `.claude/rules/workflow-test-wiring.md` で **operator 手動のみ**と定めている領域です (報酬ハック防止の最終防壁)。

今回は個別 PR が構造的に merge 不能である旨を提示したうえで、**operator の明示承認を得て実施**しています (2026-08-14)。検査の削除・弱体化は含まず、pin した SHA の更新のみです。

## 検証

- `bash scripts/ci/check-consistency.sh` → 25/25 合格
- `actionlint` は CI で検証 (ローカル未インストール)
- 3 件の dependabot PR は main 反映後に close します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZBxNEtYJbtHkZcsAn8nsv


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * セキュリティ分析およびコード品質チェックに使用するアクションを、最新の安定版へ更新しました。
  * これにより、継続的インテグレーション環境でのチェックが最新状態で実行されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->