### PR TITLE
chore(release): plugin tag を廃止し semver tag に一本化 (D69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Change history for claude-code-harness.
 
 ## [Unreleased]
 
+### Changed
+
+- **release: plugin tag (`{plugin-name}--v{version}`) を廃止し semver tag `vX.Y.Z` に一本化** (D69)。`marketplace.json` の `source` が相対パスで install は tag を参照しないため実効性が無く、v5.6.0 以降 3 リリース連続で欠番のまま実害が無かった。harness-release の手順・test pin を実態に合わせた。既存の `claude-code-harness--v5.5.0` 以前の tag は履歴として残す
+
 ## [5.9.0] - 2026-08-17
 
 ### Added

--- a/codex/.codex/skills/harness-release/SKILL.md
+++ b/codex/.codex/skills/harness-release/SKILL.md
@@ -160,7 +160,7 @@ dirty tree のまま version bump / tag / GitHub Release に進まない。
    - `Cargo.toml` (Rust, `[package]`)
 4. `gh` CLI がインストール済みで、認証済み
 5. git リモート `origin` が GitHub を指す
-6. Claude Code plugin project の場合は、`claude` CLI が `plugin tag` をサポートしている
+6. Claude Code plugin project の場合は、`claude` CLI が `plugin validate` をサポートしている
 
 これらが満たされない場合、Preflight で detect して abort します。
 
@@ -171,9 +171,9 @@ owner / branch / release asset / CI metadata の自動取得は host ごとの�
 ## 単一ゲートフロー
 
 Bare release（0. Review Gate → 0.5 Work Commit Gate）→
-Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin tag preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
+Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin version sync preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
 **単一確認ゲート**（下記「Confirmation Gate」参照、`yes` / `<修正指示>` / `cancel` の 3 択）→
-Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. plugin tag → 17. semver tag → 18. tag push → 19. workflow publish verify → 20. 完了報告）
+Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. semver tag → 17. tag push → 18. workflow publish verify → 19. 完了報告）
 の 3 段階で進む。各段の詳細は「Pre-Gate 詳細」「Confirmation Gate」「Post-Gate 詳細」を参照。
 
 ## Pre-Gate 詳細
@@ -213,11 +213,11 @@ release preflight は host workflow smoke を `REQUIRED=1`（fail-closed）で�
 `VERSION` → `package.json` → `pyproject.toml`（`[project]` / `[tool.poetry]`）→ `Cargo.toml` の優先順で探索し、最初に見つかったものを正本とする。
 検出スニペット・読み取りロジックの詳細: [version-files.md](${CLAUDE_SKILL_DIR}/references/version-files.md)
 
-### 3. Claude Plugin Tag Preflight
+### 3. Claude Plugin Version Sync Preflight
 
-`.claude-plugin/plugin.json` が存在する project では、通常の GitHub Release tag とは別に Claude plugin release tag も作る。
+`.claude-plugin/plugin.json` が存在する project では、semver tag を切る前に plugin manifest の validation と全 version surface の同期を確認する。
 
-ひとことで言うと、`git tag -a` を手で組み立てる前に、Claude Code 本体の plugin validation に通してから `{plugin-name}--v{version}` tag を作る。
+> **plugin tag (`{plugin-name}--v{version}`) は 2026-08-17 に廃止**。`marketplace.json` の `source` が相対パス (`"./"`) で install は tag を参照しないため、実効性が無いまま v5.6.0 以降 3 リリース連続で欠番になっていた。GitHub Release 用 semver tag `vX.Y.Z` に一本化する (decisions.md D69)。
 
 Pre-Gate ではファイルを書き換えず、以下を確認する。
 version sync は `grep` / `sed` で拾わず、JSON は structured parser で読む:
@@ -228,8 +228,6 @@ claude plugin validate .claude-plugin/plugin.json
 
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
-
-claude plugin tag .claude-plugin --dry-run
 ```
 
 `${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py` は、存在する release surface をすべて読み取り、canonical を `VERSION > package.json > .claude-plugin/plugin.json > .codex-plugin/plugin.json` の順で決める。
@@ -255,7 +253,7 @@ python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root . 
 - `package.json` / marketplace entry の version が古いまま release workflow に進む事故
 - plugin manifest / marketplace entry の validation を通さず、あとで plugin install / update 側で詰まる事故
 
-`--dry-run` では `claude plugin tag` が実際に作る tag 名と内部の `git tag -a` / push 相当コマンドが見える。ここで見えた command を Confirmation Gate の plan に含める。
+この check の結果 (canonical version と各 surface の一致) を Confirmation Gate の plan に含める。
 
 ### 4. Bump 自動推定
 
@@ -302,8 +300,7 @@ Release Plan: v<old> → v<new> (<bump>)
    - git push origin <release-branch>
    - gh pr create/update + gh pr merge into <default-branch>
    - git fetch origin <default-branch> && git checkout <default-branch>
-   - claude plugin tag .claude-plugin --push --remote origin  # plugin project の場合。default branch 上で実行
-   - git tag -a v<new>                                        # GitHub Release 用 semver tag が必要な場合。default branch 上で作成
+   - git tag -a v<new>                                        # GitHub Release 用 semver tag。default branch 上で作成
    - git push origin <default-branch> --tags
    - (tag push 後は GitHub Actions release workflow が自動で release 公開)
 
@@ -319,13 +316,13 @@ Proceed? [yes / cancel / <修正指示>]
 | ファイル書き換え失敗 | そこで abort、ローカルは dirty なまま人間が判断 |
 | commit 失敗 | hook 拒否等。ユーザーに原因を提示して修正を促す |
 | PR 作成/merge 失敗 | release を未完了として停止。tag / GitHub Release には進まない |
-| plugin tag validation 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
+| plugin version sync 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
 | push 失敗 | リモート側の問題。ローカル commit/tag は残す |
 
-### PR / Main Merge Gate、plugin tag、Verify Publish
+### PR / Main Merge Gate、semver tag、Verify Publish
 
 Post-Gate の release commit 後、tag を作る前に GitHub PR を default branch へ merge する（`gh pr create` → `gh pr merge --merge` → default branch fetch/checkout で release commit の到達可能性を確認）。release branch 上だけに存在する commit を指す tag で GitHub Release を作ってはいけない。
-`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから `claude plugin tag .claude-plugin --push --remote origin` で plugin tag（`{plugin-name}--v{version}` 形式）を作る。
+`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから semver tag `vX.Y.Z` を作る (plugin tag は 2026-08-17 廃止、D69)。
 tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/release.yml` の公開結果を verify する（5 秒間隔 × 60 回 polling、exit 0=PASS / 2=WARN(timeout) / 3=ERROR）。
 コマンド全文・失敗時の判断基準は [post-gate-detail.md](${CLAUDE_SKILL_DIR}/references/post-gate-detail.md) を参照。
 
@@ -333,7 +330,7 @@ tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/
 
 Pre-Gate 全てを実行し、Confirmation Gate までの内容を表示するが、**gate で止まり Post-Gate に進まない**。
 
-Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` と `claude plugin tag .claude-plugin --dry-run` を実行し、実際に作られる plugin tag 名と push 対象を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
+Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` を実行し、canonical version と各 surface の一致を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
 
 ## 環境変数
 

--- a/codex/.codex/skills/harness-release/references/post-gate-detail.md
+++ b/codex/.codex/skills/harness-release/references/post-gate-detail.md
@@ -1,8 +1,8 @@
-# Post-Gate Mechanics: PR/Main Merge, Plugin Tag, Verify Publish
+# Post-Gate Mechanics: PR/Main Merge, Semver Tag, Verify Publish
 
 Full command sequences for the three Post-Gate steps the main `SKILL.md` only
 summarizes: merging the release PR into the default branch, creating the
-Claude plugin tag, and verifying the tag-triggered publish workflow.
+semver tag, and verifying the tag-triggered publish workflow.
 
 ## PR / Main Merge Gate
 
@@ -28,17 +28,17 @@ tag はこの Gate 完了後、default branch の HEAD もしくは release comm
 
 ## Claude plugin project の tag 作成
 
-`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから plugin tag を作る:
+`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから semver tag を作る:
 
 ```bash
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
 
-claude plugin tag .claude-plugin --dry-run
-claude plugin tag .claude-plugin --push --remote origin
+git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+git push origin "v${NEW_VERSION}"
 ```
 
-`claude plugin tag` が作る tag は `{plugin-name}--v{version}` 形式。既存の GitHub Release workflow が `vX.Y.Z` tag を前提にしている project では、plugin tag とは別に `git tag -a v<new>` を作る。plugin 配布の tag は `claude plugin tag` に任せ、GitHub Release 用 semver tag は release automation の互換 surface として扱う。
+tag は `vX.Y.Z` 形式の semver tag 1 本に統一する。`claude plugin tag` が作る `{plugin-name}--v{version}` 形式の plugin tag は 2026-08-17 に廃止した (decisions.md D69): `marketplace.json` の `source` が相対パス `"./"` で install は tag を参照しないため実効性が無く、v5.6.0 以降 3 リリース連続で欠番のまま誰も困らなかった。既存の `claude-code-harness--v5.5.0` 以前の tag は履歴として残すが、新規には作らない。
 
 ## Verify Workflow Publish
 

--- a/codex/.codex/skills/harness-release/references/versioning.md
+++ b/codex/.codex/skills/harness-release/references/versioning.md
@@ -74,7 +74,7 @@ v3.6.1 (03/09) — Auto Mode 準備         ← prep は patch
 - 見出し照合は `### Breaking` の **prefix match**（`skills/harness-release/references/bump-detection.md`
   の正記法 `### Breaking Changes` も同一トリガーとして扱う）。実装正本は
   `go/internal/releasetrain`（`harness release --check`）。対象 tag は `v[0-9]` 始まりの
-  semver tag のみ（`claude-code-harness--v*` の plugin tag は対象外）。
+  semver tag のみ（`claude-code-harness--v*` の plugin tag は 2026-08-17 に廃止済み・履歴のみ残存。D69）。
 - これは gate ではなく**提案**。無視はノーコスト、次の閾値で再提案される。Session Monitor
   に tri-state（Candidate / None / NotApplicable）で受動表示し、
   `active-watching-test-policy.md` の 3 状態命名に従う（候補なしは silent）。

--- a/docs/plugin-managed-settings-policy.md
+++ b/docs/plugin-managed-settings-policy.md
@@ -54,7 +54,7 @@ Harness の方針:
 
 - `.claude-plugin/settings.json` や project template に `DISABLE_UPDATES` を既定値として入れない。
 - 企業配布では managed settings または端末管理の環境変数として設定する。
-- update を止める場合でも、`harness-release` の version sync / plugin tag / validate flow は維持する。
+- update を止める場合でも、`harness-release` の version sync / semver tag / validate flow は維持する。
 
 ## Marketplace policy
 

--- a/opencode/skills/harness-release/SKILL.md
+++ b/opencode/skills/harness-release/SKILL.md
@@ -145,7 +145,7 @@ dirty tree のまま version bump / tag / GitHub Release に進まない。
    - `Cargo.toml` (Rust, `[package]`)
 4. `gh` CLI がインストール済みで、認証済み
 5. git リモート `origin` が GitHub を指す
-6. Claude Code plugin project の場合は、`claude` CLI が `plugin tag` をサポートしている
+6. Claude Code plugin project の場合は、`claude` CLI が `plugin validate` をサポートしている
 
 これらが満たされない場合、Preflight で detect して abort します。
 
@@ -156,9 +156,9 @@ owner / branch / release asset / CI metadata の自動取得は host ごとの�
 ## 単一ゲートフロー
 
 Bare release（0. Review Gate → 0.5 Work Commit Gate）→
-Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin tag preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
+Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin version sync preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
 **単一確認ゲート**（下記「Confirmation Gate」参照、`yes` / `<修正指示>` / `cancel` の 3 択）→
-Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. plugin tag → 17. semver tag → 18. tag push → 19. workflow publish verify → 20. 完了報告）
+Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. semver tag → 17. tag push → 18. workflow publish verify → 19. 完了報告）
 の 3 段階で進む。各段の詳細は「Pre-Gate 詳細」「Confirmation Gate」「Post-Gate 詳細」を参照。
 
 ## Pre-Gate 詳細
@@ -198,11 +198,11 @@ release preflight は host workflow smoke を `REQUIRED=1`（fail-closed）で�
 `VERSION` → `package.json` → `pyproject.toml`（`[project]` / `[tool.poetry]`）→ `Cargo.toml` の優先順で探索し、最初に見つかったものを正本とする。
 検出スニペット・読み取りロジックの詳細: [version-files.md](${CLAUDE_SKILL_DIR}/references/version-files.md)
 
-### 3. Claude Plugin Tag Preflight
+### 3. Claude Plugin Version Sync Preflight
 
-`.claude-plugin/plugin.json` が存在する project では、通常の GitHub Release tag とは別に Claude plugin release tag も作る。
+`.claude-plugin/plugin.json` が存在する project では、semver tag を切る前に plugin manifest の validation と全 version surface の同期を確認する。
 
-ひとことで言うと、`git tag -a` を手で組み立てる前に、Claude Code 本体の plugin validation に通してから `{plugin-name}--v{version}` tag を作る。
+> **plugin tag (`{plugin-name}--v{version}`) は 2026-08-17 に廃止**。`marketplace.json` の `source` が相対パス (`"./"`) で install は tag を参照しないため、実効性が無いまま v5.6.0 以降 3 リリース連続で欠番になっていた。GitHub Release 用 semver tag `vX.Y.Z` に一本化する (decisions.md D69)。
 
 Pre-Gate ではファイルを書き換えず、以下を確認する。
 version sync は `grep` / `sed` で拾わず、JSON は structured parser で読む:
@@ -213,8 +213,6 @@ claude plugin validate .claude-plugin/plugin.json
 
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
-
-claude plugin tag .claude-plugin --dry-run
 ```
 
 `${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py` は、存在する release surface をすべて読み取り、canonical を `VERSION > package.json > .claude-plugin/plugin.json > .codex-plugin/plugin.json` の順で決める。
@@ -240,7 +238,7 @@ python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root . 
 - `package.json` / marketplace entry の version が古いまま release workflow に進む事故
 - plugin manifest / marketplace entry の validation を通さず、あとで plugin install / update 側で詰まる事故
 
-`--dry-run` では `claude plugin tag` が実際に作る tag 名と内部の `git tag -a` / push 相当コマンドが見える。ここで見えた command を Confirmation Gate の plan に含める。
+この check の結果 (canonical version と各 surface の一致) を Confirmation Gate の plan に含める。
 
 ### 4. Bump 自動推定
 
@@ -287,8 +285,7 @@ Release Plan: v<old> → v<new> (<bump>)
    - git push origin <release-branch>
    - gh pr create/update + gh pr merge into <default-branch>
    - git fetch origin <default-branch> && git checkout <default-branch>
-   - claude plugin tag .claude-plugin --push --remote origin  # plugin project の場合。default branch 上で実行
-   - git tag -a v<new>                                        # GitHub Release 用 semver tag が必要な場合。default branch 上で作成
+   - git tag -a v<new>                                        # GitHub Release 用 semver tag。default branch 上で作成
    - git push origin <default-branch> --tags
    - (tag push 後は GitHub Actions release workflow が自動で release 公開)
 
@@ -304,13 +301,13 @@ Proceed? [yes / cancel / <修正指示>]
 | ファイル書き換え失敗 | そこで abort、ローカルは dirty なまま人間が判断 |
 | commit 失敗 | hook 拒否等。ユーザーに原因を提示して修正を促す |
 | PR 作成/merge 失敗 | release を未完了として停止。tag / GitHub Release には進まない |
-| plugin tag validation 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
+| plugin version sync 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
 | push 失敗 | リモート側の問題。ローカル commit/tag は残す |
 
-### PR / Main Merge Gate、plugin tag、Verify Publish
+### PR / Main Merge Gate、semver tag、Verify Publish
 
 Post-Gate の release commit 後、tag を作る前に GitHub PR を default branch へ merge する（`gh pr create` → `gh pr merge --merge` → default branch fetch/checkout で release commit の到達可能性を確認）。release branch 上だけに存在する commit を指す tag で GitHub Release を作ってはいけない。
-`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから `claude plugin tag .claude-plugin --push --remote origin` で plugin tag（`{plugin-name}--v{version}` 形式）を作る。
+`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから semver tag `vX.Y.Z` を作る (plugin tag は 2026-08-17 廃止、D69)。
 tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/release.yml` の公開結果を verify する（5 秒間隔 × 60 回 polling、exit 0=PASS / 2=WARN(timeout) / 3=ERROR）。
 コマンド全文・失敗時の判断基準は [post-gate-detail.md](${CLAUDE_SKILL_DIR}/references/post-gate-detail.md) を参照。
 
@@ -318,7 +315,7 @@ tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/
 
 Pre-Gate 全てを実行し、Confirmation Gate までの内容を表示するが、**gate で止まり Post-Gate に進まない**。
 
-Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` と `claude plugin tag .claude-plugin --dry-run` を実行し、実際に作られる plugin tag 名と push 対象を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
+Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` を実行し、canonical version と各 surface の一致を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
 
 ## 環境変数
 

--- a/opencode/skills/harness-release/references/post-gate-detail.md
+++ b/opencode/skills/harness-release/references/post-gate-detail.md
@@ -1,8 +1,8 @@
-# Post-Gate Mechanics: PR/Main Merge, Plugin Tag, Verify Publish
+# Post-Gate Mechanics: PR/Main Merge, Semver Tag, Verify Publish
 
 Full command sequences for the three Post-Gate steps the main `SKILL.md` only
 summarizes: merging the release PR into the default branch, creating the
-Claude plugin tag, and verifying the tag-triggered publish workflow.
+semver tag, and verifying the tag-triggered publish workflow.
 
 ## PR / Main Merge Gate
 
@@ -28,17 +28,17 @@ tag はこの Gate 完了後、default branch の HEAD もしくは release comm
 
 ## Claude plugin project の tag 作成
 
-`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから plugin tag を作る:
+`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから semver tag を作る:
 
 ```bash
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
 
-claude plugin tag .claude-plugin --dry-run
-claude plugin tag .claude-plugin --push --remote origin
+git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+git push origin "v${NEW_VERSION}"
 ```
 
-`claude plugin tag` が作る tag は `{plugin-name}--v{version}` 形式。既存の GitHub Release workflow が `vX.Y.Z` tag を前提にしている project では、plugin tag とは別に `git tag -a v<new>` を作る。plugin 配布の tag は `claude plugin tag` に任せ、GitHub Release 用 semver tag は release automation の互換 surface として扱う。
+tag は `vX.Y.Z` 形式の semver tag 1 本に統一する。`claude plugin tag` が作る `{plugin-name}--v{version}` 形式の plugin tag は 2026-08-17 に廃止した (decisions.md D69): `marketplace.json` の `source` が相対パス `"./"` で install は tag を参照しないため実効性が無く、v5.6.0 以降 3 リリース連続で欠番のまま誰も困らなかった。既存の `claude-code-harness--v5.5.0` 以前の tag は履歴として残すが、新規には作らない。
 
 ## Verify Workflow Publish
 

--- a/opencode/skills/harness-release/references/versioning.md
+++ b/opencode/skills/harness-release/references/versioning.md
@@ -74,7 +74,7 @@ v3.6.1 (03/09) — Auto Mode 準備         ← prep は patch
 - 見出し照合は `### Breaking` の **prefix match**（`skills/harness-release/references/bump-detection.md`
   の正記法 `### Breaking Changes` も同一トリガーとして扱う）。実装正本は
   `go/internal/releasetrain`（`harness release --check`）。対象 tag は `v[0-9]` 始まりの
-  semver tag のみ（`claude-code-harness--v*` の plugin tag は対象外）。
+  semver tag のみ（`claude-code-harness--v*` の plugin tag は 2026-08-17 に廃止済み・履歴のみ残存。D69）。
 - これは gate ではなく**提案**。無視はノーコスト、次の閾値で再提案される。Session Monitor
   に tri-state（Candidate / None / NotApplicable）で受動表示し、
   `active-watching-test-policy.md` の 3 状態命名に従う（候補なしは silent）。

--- a/skills/harness-release/SKILL.md
+++ b/skills/harness-release/SKILL.md
@@ -160,7 +160,7 @@ dirty tree のまま version bump / tag / GitHub Release に進まない。
    - `Cargo.toml` (Rust, `[package]`)
 4. `gh` CLI がインストール済みで、認証済み
 5. git リモート `origin` が GitHub を指す
-6. Claude Code plugin project の場合は、`claude` CLI が `plugin tag` をサポートしている
+6. Claude Code plugin project の場合は、`claude` CLI が `plugin validate` をサポートしている
 
 これらが満たされない場合、Preflight で detect して abort します。
 
@@ -171,9 +171,9 @@ owner / branch / release asset / CI metadata の自動取得は host ごとの�
 ## 単一ゲートフロー
 
 Bare release（0. Review Gate → 0.5 Work Commit Gate）→
-Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin tag preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
+Pre-Gate（1. Preflight → 2. Version file 検出 → 3. バージョン読み取り → 4. plugin version sync preflight → 5. bump 推定 → 6. 新バージョン算出 → 7. CHANGELOG ドラフト → 8. Release notes ドラフト）→
 **単一確認ゲート**（下記「Confirmation Gate」参照、`yes` / `<修正指示>` / `cancel` の 3 択）→
-Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. plugin tag → 17. semver tag → 18. tag push → 19. workflow publish verify → 20. 完了報告）
+Post-Gate（9. Version file 書き換え → 10. CHANGELOG 昇格 → 11. commit → 12. branch push → 13. PR 作成/更新 → 14. default branch merge → 15. 到達可能性確認 → 16. semver tag → 17. tag push → 18. workflow publish verify → 19. 完了報告）
 の 3 段階で進む。各段の詳細は「Pre-Gate 詳細」「Confirmation Gate」「Post-Gate 詳細」を参照。
 
 ## Pre-Gate 詳細
@@ -213,11 +213,11 @@ release preflight は host workflow smoke を `REQUIRED=1`（fail-closed）で�
 `VERSION` → `package.json` → `pyproject.toml`（`[project]` / `[tool.poetry]`）→ `Cargo.toml` の優先順で探索し、最初に見つかったものを正本とする。
 検出スニペット・読み取りロジックの詳細: [version-files.md](${CLAUDE_SKILL_DIR}/references/version-files.md)
 
-### 3. Claude Plugin Tag Preflight
+### 3. Claude Plugin Version Sync Preflight
 
-`.claude-plugin/plugin.json` が存在する project では、通常の GitHub Release tag とは別に Claude plugin release tag も作る。
+`.claude-plugin/plugin.json` が存在する project では、semver tag を切る前に plugin manifest の validation と全 version surface の同期を確認する。
 
-ひとことで言うと、`git tag -a` を手で組み立てる前に、Claude Code 本体の plugin validation に通してから `{plugin-name}--v{version}` tag を作る。
+> **plugin tag (`{plugin-name}--v{version}`) は 2026-08-17 に廃止**。`marketplace.json` の `source` が相対パス (`"./"`) で install は tag を参照しないため、実効性が無いまま v5.6.0 以降 3 リリース連続で欠番になっていた。GitHub Release 用 semver tag `vX.Y.Z` に一本化する (decisions.md D69)。
 
 Pre-Gate ではファイルを書き換えず、以下を確認する。
 version sync は `grep` / `sed` で拾わず、JSON は structured parser で読む:
@@ -228,8 +228,6 @@ claude plugin validate .claude-plugin/plugin.json
 
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
-
-claude plugin tag .claude-plugin --dry-run
 ```
 
 `${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py` は、存在する release surface をすべて読み取り、canonical を `VERSION > package.json > .claude-plugin/plugin.json > .codex-plugin/plugin.json` の順で決める。
@@ -255,7 +253,7 @@ python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root . 
 - `package.json` / marketplace entry の version が古いまま release workflow に進む事故
 - plugin manifest / marketplace entry の validation を通さず、あとで plugin install / update 側で詰まる事故
 
-`--dry-run` では `claude plugin tag` が実際に作る tag 名と内部の `git tag -a` / push 相当コマンドが見える。ここで見えた command を Confirmation Gate の plan に含める。
+この check の結果 (canonical version と各 surface の一致) を Confirmation Gate の plan に含める。
 
 ### 4. Bump 自動推定
 
@@ -302,8 +300,7 @@ Release Plan: v<old> → v<new> (<bump>)
    - git push origin <release-branch>
    - gh pr create/update + gh pr merge into <default-branch>
    - git fetch origin <default-branch> && git checkout <default-branch>
-   - claude plugin tag .claude-plugin --push --remote origin  # plugin project の場合。default branch 上で実行
-   - git tag -a v<new>                                        # GitHub Release 用 semver tag が必要な場合。default branch 上で作成
+   - git tag -a v<new>                                        # GitHub Release 用 semver tag。default branch 上で作成
    - git push origin <default-branch> --tags
    - (tag push 後は GitHub Actions release workflow が自動で release 公開)
 
@@ -319,13 +316,13 @@ Proceed? [yes / cancel / <修正指示>]
 | ファイル書き換え失敗 | そこで abort、ローカルは dirty なまま人間が判断 |
 | commit 失敗 | hook 拒否等。ユーザーに原因を提示して修正を促す |
 | PR 作成/merge 失敗 | release を未完了として停止。tag / GitHub Release には進まない |
-| plugin tag validation 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
+| plugin version sync 失敗 | `VERSION` / `.claude-plugin/plugin.json` / marketplace entry の不一致を修正し、tag 作成には進まない |
 | push 失敗 | リモート側の問題。ローカル commit/tag は残す |
 
-### PR / Main Merge Gate、plugin tag、Verify Publish
+### PR / Main Merge Gate、semver tag、Verify Publish
 
 Post-Gate の release commit 後、tag を作る前に GitHub PR を default branch へ merge する（`gh pr create` → `gh pr merge --merge` → default branch fetch/checkout で release commit の到達可能性を確認）。release branch 上だけに存在する commit を指す tag で GitHub Release を作ってはいけない。
-`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから `claude plugin tag .claude-plugin --push --remote origin` で plugin tag（`{plugin-name}--v{version}` 形式）を作る。
+`.claude-plugin/plugin.json` がある project では、merge 後に default branch 上で version sync を再確認してから semver tag `vX.Y.Z` を作る (plugin tag は 2026-08-17 廃止、D69)。
 tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/release.yml` の公開結果を verify する（5 秒間隔 × 60 回 polling、exit 0=PASS / 2=WARN(timeout) / 3=ERROR）。
 コマンド全文・失敗時の判断基準は [post-gate-detail.md](${CLAUDE_SKILL_DIR}/references/post-gate-detail.md) を参照。
 
@@ -333,7 +330,7 @@ tag push 後は `bash scripts/release-verify-publish.sh` で `.github/workflows/
 
 Pre-Gate 全てを実行し、Confirmation Gate までの内容を表示するが、**gate で止まり Post-Gate に進まない**。
 
-Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` と `claude plugin tag .claude-plugin --dry-run` を実行し、実際に作られる plugin tag 名と push 対象を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
+Claude plugin project の場合、dry-run でも `python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .` を実行し、canonical version と各 surface の一致を表示する。ここで `VERSION` / `package.json` / `.claude-plugin/plugin.json` / `.codex-plugin/plugin.json` / `.claude-plugin/marketplace.json` の version surface が不一致または欠落していれば、dry-run の時点で止める。
 
 ## 環境変数
 

--- a/skills/harness-release/references/post-gate-detail.md
+++ b/skills/harness-release/references/post-gate-detail.md
@@ -1,8 +1,8 @@
-# Post-Gate Mechanics: PR/Main Merge, Plugin Tag, Verify Publish
+# Post-Gate Mechanics: PR/Main Merge, Semver Tag, Verify Publish
 
 Full command sequences for the three Post-Gate steps the main `SKILL.md` only
 summarizes: merging the release PR into the default branch, creating the
-Claude plugin tag, and verifying the tag-triggered publish workflow.
+semver tag, and verifying the tag-triggered publish workflow.
 
 ## PR / Main Merge Gate
 
@@ -28,17 +28,17 @@ tag はこの Gate 完了後、default branch の HEAD もしくは release comm
 
 ## Claude plugin project の tag 作成
 
-`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから plugin tag を作る:
+`.claude-plugin/plugin.json` がある project では、PR/main merge 後に default branch 上でもう一度 version sync を確認してから semver tag を作る:
 
 ```bash
 HARNESS_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-.}"
 python3 "${HARNESS_PLUGIN_ROOT}/scripts/check-release-version-sync.py" --root .
 
-claude plugin tag .claude-plugin --dry-run
-claude plugin tag .claude-plugin --push --remote origin
+git tag -a "v${NEW_VERSION}" -m "v${NEW_VERSION}"
+git push origin "v${NEW_VERSION}"
 ```
 
-`claude plugin tag` が作る tag は `{plugin-name}--v{version}` 形式。既存の GitHub Release workflow が `vX.Y.Z` tag を前提にしている project では、plugin tag とは別に `git tag -a v<new>` を作る。plugin 配布の tag は `claude plugin tag` に任せ、GitHub Release 用 semver tag は release automation の互換 surface として扱う。
+tag は `vX.Y.Z` 形式の semver tag 1 本に統一する。`claude plugin tag` が作る `{plugin-name}--v{version}` 形式の plugin tag は 2026-08-17 に廃止した (decisions.md D69): `marketplace.json` の `source` が相対パス `"./"` で install は tag を参照しないため実効性が無く、v5.6.0 以降 3 リリース連続で欠番のまま誰も困らなかった。既存の `claude-code-harness--v5.5.0` 以前の tag は履歴として残すが、新規には作らない。
 
 ## Verify Workflow Publish
 

--- a/skills/harness-release/references/versioning.md
+++ b/skills/harness-release/references/versioning.md
@@ -74,7 +74,7 @@ v3.6.1 (03/09) — Auto Mode 準備         ← prep は patch
 - 見出し照合は `### Breaking` の **prefix match**（`skills/harness-release/references/bump-detection.md`
   の正記法 `### Breaking Changes` も同一トリガーとして扱う）。実装正本は
   `go/internal/releasetrain`（`harness release --check`）。対象 tag は `v[0-9]` 始まりの
-  semver tag のみ（`claude-code-harness--v*` の plugin tag は対象外）。
+  semver tag のみ（`claude-code-harness--v*` の plugin tag は 2026-08-17 に廃止済み・履歴のみ残存。D69）。
 - これは gate ではなく**提案**。無視はノーコスト、次の閾値で再提案される。Session Monitor
   に tri-state（Candidate / None / NotApplicable）で受動表示し、
   `active-watching-test-policy.md` の 3 状態命名に従う（候補なしは silent）。

--- a/tests/test-claude-upstream-integration.sh
+++ b/tests/test-claude-upstream-integration.sh
@@ -311,14 +311,17 @@ grep -q '書き込み系 MCP tool は hook から呼ばない' "${PHASE53_SNAPSH
   exit 1
 }
 
-# Phase 53.1.3: claude plugin tag must be visible in release preflight / dry-run guidance
+# Phase 53.1.3 (superseded 2026-08-17, D69): the plugin tag (`{plugin-name}--v{version}`)
+# was retired because marketplace.json's relative source means install never reads it.
+# The release skill must NOT invoke `claude plugin tag` anymore, but must keep the
+# structured version-sync preflight that 53.1.3 also introduced.
 HARNESS_RELEASE_SKILL="${ROOT_DIR}/skills/harness-release/SKILL.md"
-grep -q 'claude plugin tag .claude-plugin --dry-run' "${HARNESS_RELEASE_SKILL}" || {
-  echo "harness-release is missing claude plugin tag dry-run guidance"
+if grep -q 'claude plugin tag .claude-plugin' "${HARNESS_RELEASE_SKILL}"; then
+  echo "harness-release must not invoke 'claude plugin tag' (retired 2026-08-17, D69)"
   exit 1
-}
-grep -q 'claude plugin tag .claude-plugin --push --remote origin' "${HARNESS_RELEASE_SKILL}" || {
-  echo "harness-release is missing claude plugin tag push guidance"
+fi
+grep -q 'plugin tag' "${HARNESS_RELEASE_SKILL}" || {
+  echo "harness-release must record the plugin tag retirement so operators can find the rationale"
   exit 1
 }
 grep -q 'check-release-version-sync.py' "${HARNESS_RELEASE_SKILL}" || {
@@ -333,6 +336,9 @@ grep -q '53.1.3 plugin tag release flow decision' "${PHASE53_SNAPSHOT_DOC}" || {
   echo "Phase 53 snapshot is missing the 53.1.3 plugin tag release flow decision"
   exit 1
 }
+# The snapshot doc is a historical record of the 2026-04-23 decision and keeps the
+# original dry-run command; the retirement is recorded in decisions.md D69, not by
+# rewriting the snapshot.
 grep -q 'claude plugin tag .claude-plugin --dry-run' "${PHASE53_SNAPSHOT_DOC}" || {
   echo "Phase 53 snapshot must record the claude plugin tag dry-run command"
   exit 1


### PR DESCRIPTION
## Summary
- \`claude plugin tag\` が作る plugin tag (\`{plugin-name}--v{version}\`) を release flow から廃止し、semver tag \`vX.Y.Z\` に一本化
- 理由: \`marketplace.json\` の \`source\` が相対パス \`"./"\` で install は tag を参照しない。v5.6.0 以降 3 リリース連続で欠番のまま実害ゼロ = 手順書と実行の乖離だった。手順書側を実態に合わせる (decisions.md D69)
- 既存の \`claude-code-harness--v5.5.0\` 以前の tag は履歴として残す

## Changes
- harness-release SKILL.md / post-gate-detail.md / versioning.md: 呼び出し除去 + 廃止理由明記
- tests/test-claude-upstream-integration.sh: pin を「呼び出しが無いこと」へ反転 (RED 実測済み)。Phase 53 snapshot doc は歴史記録として不変更
- decisions.md D69 / CHANGELOG [Unreleased] / docs/plugin-managed-settings-policy.md / codex・opencode mirror 同期

## Test plan
- [x] tests/test-claude-upstream-integration.sh OK (旧 SKILL.md で FAIL することも実測)
- [x] scripts/ci/check-consistency.sh PASS
- [x] tests/validate-plugin.sh 全 PASS
- [x] mirror --check healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リリースタグを `vX.Y.Z` 形式の標準的な semver タグに統一しました。
  * リリース前後に、マニフェスト検証と各バージョン情報の同期確認を行うようにしました。

* **ドキュメント**
  * 新しいタグ方針、リリース手順、既存の旧形式タグの扱いを更新しました。
  * dry-run とリリース検証の手順を新しい運用に合わせて更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->